### PR TITLE
-init이 기본 인증서 생성을 하도록 함

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ cd $GOPATH/src/github.com/studio2l/roi/cmd/roishot
 go build
 ./roishot testdata/test.xlsx
 
-# 자가 https 인증서 추가
-cd $GOPATH/src/github.com/studio2l/roi/cmd/roi/cert
-sh generate-self-signed-cert.sh
-
 # 서버 실행
 cd $GOPATH/src/github.com/studio2l/roi/cmd/roi
 go build

--- a/cmd/roi/check.go
+++ b/cmd/roi/check.go
@@ -1,0 +1,19 @@
+package main
+
+import "os"
+
+// anyFileExist는 받아들인 파일 중 하나라도 존재한다면 true를
+// 모든 파일이 존재하지 않는다면 false를 반환한다.
+// 만일 파일 검사 중 에러가 발생하면 false와 해당 에러를 반환한다.
+func anyFileExist(files ...string) (bool, error) {
+	for _, f := range files {
+		if _, err := os.Stat(f); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
인증서 생성은 https 개념을 알지 못하는 사용자에게는 어려운 과정이다.

이를 -init에 넣어 초기 세팅 과정을 돕는다.