### PR TITLE
README: travis 배지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # roi
 
+[![Build Status](https://travis-ci.com/studio2l/roi.svg?branch=master)](https://travis-ci.com/studio2l/roi)
+
 roi는 2L의 새 파이프라인 서버이자, 첫번째 오픈소스 프로젝트입니다!
 
 


### PR DESCRIPTION
master 브랜치의 빌드 상태를 알 수 있는 travis 배지를 README에 추가합니다. 