### PR TITLE
DB와 관련된 함수중 쓰지 않는 SelectAll과 pgIndices 삭제

### DIFF
--- a/db.go
+++ b/db.go
@@ -31,33 +31,3 @@ func InitTables(db *sql.DB) error {
 	}
 	return nil
 }
-
-// SelectAll은 특정 db 테이블의 모든 열을 검색하여 *sql.Rows 형태로 반환한다.
-func SelectAll(db *sql.DB, table string, where map[string]string) (*sql.Rows, error) {
-	stmt := fmt.Sprintf("SELECT * FROM %s", table)
-	if len(where) != 0 {
-		wheres := ""
-		for k, v := range where {
-			if wheres != "" {
-				wheres += " AND "
-			}
-			wheres += fmt.Sprintf("(%s = '%s')", k, v)
-		}
-		stmt += " WHERE " + wheres
-	}
-	fmt.Println(stmt)
-	return db.Query(stmt)
-}
-
-// pgIndices는 "$1" 부터 "$n"까지의 문자열 슬라이스를 반환한다.
-// 이는 postgres에 대한 db.Exec나 db.Query를 위한 질의문을 만들때 유용하게 쓰인다.
-func pgIndices(n int) []string {
-	if n <= 0 {
-		return []string{}
-	}
-	idxs := make([]string, n)
-	for i := 0; i < n; i++ {
-		idxs[i] = fmt.Sprintf("$%d", i+1)
-	}
-	return idxs
-}


### PR DESCRIPTION
한 때 사용했지만 더 명확한 코드를 선호하면서 더 이상 쓰지 않는다.