### PR TITLE
시간, 시간 문자열과 관련된 함수 정리 및 폼 유효성 검사

### DIFF
--- a/cmd/roi/main.go
+++ b/cmd/roi/main.go
@@ -48,7 +48,7 @@ func stringFromTime(t *time.Time) string {
 }
 
 // timeFromString는 rfc3339 형식의 문자열에서 시간을 얻는다.
-// 만일 형식이 틀려 에러가 나면 그냥 로그로 남긴다.
+// 받은 문자열이 형식에 맞지 않으면 에러를 반환한다.
 func timeFromString(s string) (time.Time, error) {
 	return time.Parse(time.RFC3339, s)
 }

--- a/cmd/roi/tmpl/projects.html
+++ b/cmd/roi/tmpl/projects.html
@@ -5,7 +5,7 @@
 {{range .Projects}}
 <div class="ui inverted segment">
 	<div>ID:{{.ID}}, 상태:{{if ne .Status ""}}{{.Status}}{{else}}없음{{end}}</div>
-	<div>시작일:{{dateTime .StartDate}} 종료일:{{dateTime .ReleaseDate}}</div>
+	<div>시작일:{{stringFromTime .StartDate}} 종료일:{{stringFromTime .ReleaseDate}}</div>
 	<div><a href="/update-project?id={{.ID}}">수정</a></div>
 </div>
 {{end}}

--- a/cmd/roi/tmpl/update-project.html
+++ b/cmd/roi/tmpl/update-project.html
@@ -33,19 +33,19 @@
 			<input type="text" name="cg_supervisor" value="{{.Project.CGSupervisor}}"/>
 		</div>
 		<div class="field"><label>크랭크 인</label>
-			<input type="text" name="crank_in" value="{{dateTime .Project.CrankIn}}"/>
+			<input type="text" name="crank_in" value="{{stringFromTime .Project.CrankIn}}"/>
 		</div>
 		<div class="field"><label>크랭크 업</label>
-			<input type="text" name="crank_up" value="{{dateTime .Project.CrankUp}}"/>
+			<input type="text" name="crank_up" value="{{stringFromTime .Project.CrankUp}}"/>
 		</div>
 		<div class="field"><label>시작일</label>
-			<input type="text" name="start_date" value="{{dateTime .Project.StartDate}}"/>
+			<input type="text" name="start_date" value="{{stringFromTime .Project.StartDate}}"/>
 		</div>
 		<div class="field"><label>종료일</label>
-			<input type="text" name="release_date" value="{{dateTime .Project.ReleaseDate}}"/>
+			<input type="text" name="release_date" value="{{stringFromTime .Project.ReleaseDate}}"/>
 		</div>
 		<div class="field"><label>VFX 종료일</label>
-			<input type="text" name="vfx_due_date" value="{{dateTime .Project.VFXDueDate}}"/>
+			<input type="text" name="vfx_due_date" value="{{stringFromTime .Project.VFXDueDate}}"/>
 		</div>
 		<div class="field"><label>아웃풋 사이즈</label>
 			<input type="text" name="output_size" value="{{.Project.OutputSize}}"/>

--- a/cmd/roi/tmpl/update-version.html
+++ b/cmd/roi/tmpl/update-version.html
@@ -30,7 +30,7 @@
 			<input type="text" name="work_file" value="{{.Version.WorkFile}}"/>
 		</div>
 		<div class="field"><label>생성일</label>
-			<input type="text" name="created" value="{{.Version.Created}}"/>
+			<input type="text" name="created" value="{{stringFromTime .Version.Created}}"/>
 		</div>
 		<button class="ui button green" type="submit" value="Submit">수정</button>
 


### PR DESCRIPTION
앞으로 시간 포맷은 rfc3339를 쓴다.

rfc3339 형식은 다음과 같다: 2006-01-02T15:04:05Z07:00

이 형식을 선택한 이유는 Go에 미리 정의되어있는 형식중
가장 정규화가 잘 되어있기 때문이다.

크게 보면 날짜T시간Z타임존 으로 나뉘며,

시간까지 보면 왼쪽은 큰 시간단위, 오른쪽은 작은 시간 단위를 의미한다.

Z에서 잘라서 앞쪽만 쓰면 존을 제외한 시간이 되고,
T에서 잘라서 앞쪽만 쓰면 존을 제외한 날짜가 된다.

Close: #183