### PR TITLE
semantic-ui에서 사용하는 색상을 css 변수로 지정함

### DIFF
--- a/cmd/roi/static/roi.css
+++ b/cmd/roi/static/roi.css
@@ -1,16 +1,17 @@
 :root {
-	--red: #B03060;
-	--orange: #FE9A76;
-	--yellow: #FFD700;
-	--olive: #32CD32;
-	--green: #016936;
-	--teal: #008080;
-	--blue: #0E6EB8;
-	--violet: #EE82FE;
-	--pulple: #B413EC;
-	--pink: #FF1493;
-	--brown: #A52A2A;
-	--grey: #A0A0A0;
+	--red: #DB2828;
+	--orange: #F2711C;
+	--yellow: #FBBD08;
+	--olive: #B5CC18;
+	--green: #21BA45;
+	--teal: #00B5AD;
+	--blue: #2185D0;
+	--violet: #6435C9;
+	--pulple: #A333C8;
+	--pink: #E03997;
+	--brown: #A5673F;
+	--grey: #767676;
+	--black: #1B1C1D;
 }
 
 body {

--- a/cmd/roi/static/roi.css
+++ b/cmd/roi/static/roi.css
@@ -1,3 +1,18 @@
+:root {
+	--red: #B03060;
+	--orange: #FE9A76;
+	--yellow: #FFD700;
+	--olive: #32CD32;
+	--green: #016936;
+	--teal: #008080;
+	--blue: #0E6EB8;
+	--violet: #EE82FE;
+	--pulple: #B413EC;
+	--pink: #FF1493;
+	--brown: #A52A2A;
+	--grey: #A0A0A0;
+}
+
 body {
 	background-color:#EEEEEE;
 	margin: 0;


### PR DESCRIPTION
semantic-ui는 red, green, blue 같은 클래스 이름을 만나면
해당하는 html 기본 색상이 아니라 직접 정의한 색상을 사용한다.
따라서 semantic-ui로 만들기 어려운 엘리먼트 레이아웃을 짤 때
컬러를 사용하면 ui를 사용한 색상과 컬러가 맞지 않는다.
semantic-ui에서 사용하는 컬러를 사용하도록 css 변수를 작성하였다.