### PR TITLE
all: 모든 스트럭트와 DB 필드에서 ID 대신 그 스트럭트 이름을 사용

### DIFF
--- a/cmd/roi/api.go
+++ b/cmd/roi/api.go
@@ -65,7 +65,7 @@ func addProjectApiHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p := &roi.Project{
-		ID: prj,
+		Project: prj,
 	}
 	err = roi.AddProject(db, p)
 	if err != nil {
@@ -109,7 +109,7 @@ func addShotApiHandler(w http.ResponseWriter, r *http.Request) {
 		apiBadRequest(w, fmt.Errorf("shot 'id' not specified"))
 		return
 	}
-	if !roi.IsValidShotID(id) {
+	if !roi.IsValidShot(id) {
 		apiBadRequest(w, fmt.Errorf("shot id '%s' is not valid", id))
 		return
 	}
@@ -155,8 +155,8 @@ func addShotApiHandler(w http.ResponseWriter, r *http.Request) {
 		duration = int(f)
 	}
 	s := &roi.Shot{
-		ProjectID:     prj,
-		ID:            id,
+		Project:       prj,
+		Shot:          id,
 		Status:        roi.ShotStatus(status),
 		EditOrder:     editOrder,
 		Description:   r.PostFormValue("description"),

--- a/cmd/roi/project_handler.go
+++ b/cmd/roi/project_handler.go
@@ -99,7 +99,7 @@ func addProjectHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		p := &roi.Project{
-			ID:            id,
+			Project:       id,
 			Name:          r.Form.Get("name"),
 			Status:        "waiting",
 			Client:        r.Form.Get("client"),

--- a/cmd/roi/root_handler.go
+++ b/cmd/roi/root_handler.go
@@ -39,14 +39,14 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 	// tasksOfDay 또한 아이디 기준으로 정렬된다.
 	sort.Slice(tasks, func(i, j int) bool {
 		ti := tasks[i]
-		idi := ti.ProjectID + "." + ti.ShotID + "." + ti.Name
+		idi := ti.Project + "." + ti.Shot + "." + ti.Task
 		tj := tasks[j]
-		idj := tj.ProjectID + "." + tj.ShotID + "." + tj.Name
+		idj := tj.Project + "." + tj.Shot + "." + tj.Task
 		return strings.Compare(idi, idj) <= 0
 	})
 	taskFromID := make(map[string]*roi.Task)
 	for _, t := range tasks {
-		tid := t.ProjectID + "." + t.ShotID + "." + t.Name
+		tid := t.Project + "." + t.Shot + "." + t.Task
 		taskFromID[tid] = t
 	}
 	tasksOfDay := make(map[time.Time][]string, 28)
@@ -54,7 +54,7 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 		if tasksOfDay[t.DueDate] == nil {
 			tasksOfDay[t.DueDate] = make([]string, 0)
 		}
-		tid := t.ProjectID + "." + t.ShotID + "." + t.Name
+		tid := t.Project + "." + t.Shot + "." + t.Task
 		tasksOfDay[t.DueDate] = append(tasksOfDay[t.DueDate], tid)
 	}
 	// 앞으로 4주에 대한 태스크 정보를 보인다.
@@ -67,10 +67,10 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	numTasks := make(map[string]map[roi.TaskStatus]int)
 	for _, t := range tasks {
-		if numTasks[t.ProjectID] == nil {
-			numTasks[t.ProjectID] = make(map[roi.TaskStatus]int)
+		if numTasks[t.Project] == nil {
+			numTasks[t.Project] = make(map[roi.TaskStatus]int)
 		}
-		numTasks[t.ProjectID][t.Status] += 1
+		numTasks[t.Project][t.Status] += 1
 	}
 	recipt := struct {
 		LoggedInUser  string

--- a/cmd/roi/shot_handler.go
+++ b/cmd/roi/shot_handler.go
@@ -93,8 +93,8 @@ func addShotHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		tasks := fields(r.Form.Get("working_tasks"), ",")
 		s := &roi.Shot{
-			ID:            shot,
-			ProjectID:     prj,
+			Shot:          shot,
+			Project:       prj,
 			Status:        roi.ShotWaiting,
 			EditOrder:     atoi(r.Form.Get("edit_order")),
 			Description:   r.Form.Get("description"),
@@ -113,9 +113,9 @@ func addShotHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, task := range tasks {
 			t := &roi.Task{
-				ProjectID: prj,
-				ShotID:    shot,
-				Name:      task,
+				Project: prj,
+				Shot:    shot,
+				Task:    task,
 			}
 			roi.AddTask(db, prj, shot, t)
 		}
@@ -222,11 +222,11 @@ func updateShotHandler(w http.ResponseWriter, r *http.Request) {
 		// 샷에 등록된 태스크 중 기존에 없었던 태스크가 있다면 생성한다.
 		for _, task := range tasks {
 			t := &roi.Task{
-				ProjectID: prj,
-				ShotID:    shot,
-				Name:      task,
-				Status:    roi.TaskNotSet,
-				DueDate:   time.Time{},
+				Project: prj,
+				Shot:    shot,
+				Task:    task,
+				Status:  roi.TaskNotSet,
+				DueDate: time.Time{},
 			}
 			tid := prj + "." + shot + "." + task
 			exist, err := roi.TaskExist(db, prj, shot, task)
@@ -265,7 +265,7 @@ func updateShotHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	tm := make(map[string]*roi.Task)
 	for _, t := range ts {
-		tm[t.Name] = t
+		tm[t.Task] = t
 	}
 	recipt := struct {
 		LoggedInUser  string

--- a/cmd/roi/tmpl/index.html
+++ b/cmd/roi/tmpl/index.html
@@ -57,9 +57,9 @@
 let taskFromID = {
 	{{range $id, $t := $.TaskFromID -}}
 	"{{$id}}": {
-		"project": "{{$t.ProjectID}}",
-		"shot": "{{$t.ShotID}}",
-		"name": "{{$t.Name}}",
+		"project": "{{$t.Project}}",
+		"shot": "{{$t.Shot}}",
+		"name": "{{$t.Task}}",
 		"status": "{{$t.Status}}",
 	},
 	{{end}}

--- a/cmd/roi/tmpl/projects.html
+++ b/cmd/roi/tmpl/projects.html
@@ -4,9 +4,9 @@
 <!--검색 결과-->
 {{range .Projects}}
 <div class="ui inverted segment">
-	<div>ID:{{.ID}}, 상태:{{if ne .Status ""}}{{.Status}}{{else}}없음{{end}}</div>
+	<div>ID:{{.Project}}, 상태:{{if ne .Status ""}}{{.Status}}{{else}}없음{{end}}</div>
 	<div>시작일:{{stringFromTime .StartDate}} 종료일:{{stringFromTime .ReleaseDate}}</div>
-	<div><a href="/update-project?id={{.ID}}">수정</a></div>
+	<div><a href="/update-project?id={{.Project}}">수정</a></div>
 </div>
 {{end}}
 </div>

--- a/cmd/roi/tmpl/search.html
+++ b/cmd/roi/tmpl/search.html
@@ -8,19 +8,19 @@
 	<div class="shot-head" style="height:20px;display:flex;align-items:end;margin-bottom:4px;font-size:15px;">
 		<div class="ui" style="width:288px;margin-right:22px;display:flex;align-items:end;">
 				<div style="display:flex;flex-direction:column;">
-					<div style="font-size:1.3rem;color:white;"><b>{{.ID}}</b></div>
+					<div style="font-size:1.3rem;color:white;"><b>{{.Shot}}</b></div>
 					<div style="height:2px;border-radius:1px;background-color:var(--{{.Status.UIColor}});"></div>
 				</div>
 				<div style="width:1rem;display:inline-block;"></div>
 				<div style="flex:1;"></div>
-				<a style="font-size:0.7rem;color:#666666;" href="/update-shot?project_id={{$.Project}}&id={{.ID}}">수정</a>
+				<a style="font-size:0.7rem;color:#666666;" href="/update-shot?project_id={{$.Project}}&id={{.Shot}}">수정</a>
 		</div>
 		<div style="flex:1;font-size:14px;"> {{.CGDescription}}</div>
 	</div>
 	<div class="shot-main" style="display:flex;margin-bottom:6px;">
 		<div style="width:288px;margin-right:22px;">
-			{{if hasThumbnail $.Project .ID}}
-			<img style="width:288px;height:162px;" src="/thumbnail/{{$.Project}}/{{.ID}}.png" />
+			{{if hasThumbnail $.Project .Shot}}
+			<img style="width:288px;height:162px;" src="/thumbnail/{{$.Project}}/{{.Shot}}.png" />
 			{{else}}
 			<div style="box-sizing:border-box;width:288px;height:162px;color:#444444;background-color:#BBBBBB;font-size:12px;padding:4px;">{{.Description}}</div>
 			{{end}}
@@ -33,14 +33,14 @@
 			<table class="ui very compact striped inverted celled table">
 				<tbody>
 					{{range .WorkingTasks}}
-					{{with index (index $.Tasks $s.ID) .}}
+					{{with index (index $.Tasks $s.Shot) .}}
 					<tr style="font-size:0.9rem;color:#AAAAAA">
 						<td class="ui one wide left aligned">
 							<div style="display:flex;padding:0 0.5rem;">
 								<div style="flex:1;display:inline-block;">
-									<a href="" style="color:white;">{{.Name}}</a>
+									<a href="" style="color:white;">{{.Task}}</a>
 								</div>
-								<a style="font-size:0.7rem;color:#666666;" href="/update-task?project_id={{$.Project}}&shot_id={{.ShotID}}&name={{.Name}}">수정</a>
+								<a style="font-size:0.7rem;color:#666666;" href="/update-task?project_id={{$.Project}}&shot_id={{.Shot}}&name={{.Task}}">수정</a>
 							</div>
 						</td>
 						<td class="one wide center aligned">
@@ -54,7 +54,7 @@
 						</td>
 						<td class="one wide center aligned">
 								{{if .LastOutputVersion}}
-									<a href="/version/{{.ProjectID}}/{{.ShotID}}/{{.Name}}/{{.LastOutputVersion}}" style="color:#AAAAAA;">{{printf "v%03d" .LastOutputVersion}}</a>
+									<a href="/version/{{.Project}}/{{.Shot}}/{{.Task}}/{{.LastOutputVersion}}" style="color:#AAAAAA;">{{printf "v%03d" .LastOutputVersion}}</a>
 								{{end}}
 						</td>
 						<td class="one wide right aligned">

--- a/cmd/roi/tmpl/update-shot.html
+++ b/cmd/roi/tmpl/update-shot.html
@@ -6,10 +6,10 @@
 	<h2 class="ui dividing header">샷 수정</h2>
 	<form method="post" class="ui form">
 		<div class="field disabled"><label>프로젝트</label>
-			<input type="text" name="project_id" value="{{.Shot.ProjectID}}"/>
+			<input type="text" name="project_id" value="{{.Shot.Project}}"/>
 		</div>
 		<div class="field disabled"><label>아이디</label>
-			<input type="text" name="id" value="{{.Shot.ID}}"/>
+			<input type="text" name="id" value="{{.Shot.Shot}}"/>
 		</div>
 		<div class="field"><label>마감일</label>
 			<div class="ui calendar" id="duedate">
@@ -69,29 +69,29 @@
 	<div class="ui form">
 		{{range $.Shot.WorkingTasks}}
 		{{with $t := index $.Tasks .}}
-		<div id="task-{{$t.Name}}" style="border:solid 1px grey;border-radius:8px;padding:15px;background-color:grey;">
+		<div id="task-{{$t.Task}}" style="border:solid 1px grey;border-radius:8px;padding:15px;background-color:grey;">
 			<div class="field">
-				<label class="ui grey label" style="font-size:1.3rem;">{{$t.Name}}</label>
+				<label class="ui grey label" style="font-size:1.3rem;">{{$t.Task}}</label>
 			</div>
 			<div class="field"><label>상태</label>
-				<select id="task-{{$t.Name}}-status" type="text" value="{{$t.Status}}">
+				<select id="task-{{$t.Task}}-status" type="text" value="{{$t.Status}}">
 					{{range $s := $.AllTaskStatus}}
 					<option value="{{$s}}" {{if eq $t.Status $s}}selected{{end}}>{{$s.UIString}}</option>
 					{{end}}
 				</select>
 			</div>
 			<div class="field"><label>담당</label>
-				<input id="task-{{$t.Name}}-assignee"  type="text" value="{{$t.Assignee}}" />
+				<input id="task-{{$t.Task}}-assignee"  type="text" value="{{$t.Assignee}}" />
 			</div>
 			<div class="field"><label>마감일</label>
-				<div class="ui calendar" id="task-{{$t.Name}}-due_date-parent">
+				<div class="ui calendar" id="task-{{$t.Task}}-due_date-parent">
 					<div class="ui input left icon">
-						<i class="calendar icon"></i><input type="text" id="task-{{$t.Name}}-due_date" value="{{with $t.DueDate}}{{if not .IsZero}}{{.}}{{end}}{{end}}">
+						<i class="calendar icon"></i><input type="text" id="task-{{$t.Task}}-due_date" value="{{with $t.DueDate}}{{if not .IsZero}}{{.}}{{end}}{{end}}">
 					</div>
 				</div>
 			</div>
 			<script>
-			$('#task-{{$t.Name}}-due_date-parent').calendar({
+			$('#task-{{$t.Task}}-due_date-parent').calendar({
 				type: 'date',
 				formatter: {
 					date: (date, settings) => {
@@ -100,8 +100,8 @@
 				}
 			});
 			</script>
-			<button id="task-{{$t.Name}}-btn" class="ui button teal" onclick="updateTask('{{$t.Name}}')">수정</button>
-			<div id="task-{{$t.Name}}-update-result" class="ui"></div>
+			<button id="task-{{$t.Task}}-btn" class="ui button teal" onclick="updateTask('{{$t.Task}}')">수정</button>
+			<div id="task-{{$t.Task}}-update-result" class="ui"></div>
 		</div>
 		<div style="height:2rem;"></div>
 		{{end}}
@@ -116,8 +116,8 @@ function updateTask(name) {
 	let assignee = document.getElementById("task-" + name + "-assignee").value;
 	let due = encodeURIComponent(document.getElementById("task-" + name + "-due_date").value);
 	let param = new Array(
-		"project_id={{$.Shot.ProjectID}}",
-		"shot_id={{$.Shot.ID}}",
+		"project_id={{$.Shot.Project}}",
+		"shot_id={{$.Shot.Shot}}",
 		"name=" + name,
 		"status=" + status,
 		"assignee=" + assignee,

--- a/cmd/roi/tmpl/update-task.html
+++ b/cmd/roi/tmpl/update-task.html
@@ -6,13 +6,13 @@
 	<h2 class="ui dividing header">태스크 수정</h2>
 	<form method="post" class="ui form">
 		<div class="field disabled"><label>프로젝트</label>
-			<input type="text" name="project_id" value="{{.Task.ProjectID}}"/>
+			<input type="text" name="project_id" value="{{.Task.Project}}"/>
 		</div>
 		<div class="field disabled"><label>샷</label>
-			<input type="text" name="shot_id" value="{{.Task.ShotID}}"/>
+			<input type="text" name="shot_id" value="{{.Task.Shot}}"/>
 		</div>
 		<div class="field disabled"><label>태스크</label>
-			<input type="text" name="name" value="{{.Task.Name}}"/>
+			<input type="text" name="name" value="{{.Task.Task}}"/>
 		</div>
 		<div class="field disabled"><label>담당</label>
 			<input type="text" name="assignee" value="{{.Task.Assignee}}"/>
@@ -50,11 +50,11 @@
 
 	<h2 class="ui dividing header">
 		버전
-		<a href="/add-version?project_id={{$.Task.ProjectID}}&shot_id={{$.Task.ShotID}}&task_name={{$.Task.Name}}" class="ui right floated mini basic inverted button">추가</a>
+		<a href="/add-version?project_id={{$.Task.Project}}&shot_id={{$.Task.Shot}}&task_name={{$.Task.Task}}" class="ui right floated mini basic inverted button">추가</a>
 	</h2>
 	<div class="ui container">
 		{{range $v := $.Versions}}
-		<a href="/update-version?project_id={{$.Task.ProjectID}}&shot_id={{$.Task.ShotID}}&task_name={{$.Task.Name}}&version={{$v}}" class="ui label">{{printf "v%d" $v}}</a>
+		<a href="/update-version?project_id={{$.Task.Project}}&shot_id={{$.Task.Shot}}&task_name={{$.Task.Task}}&version={{$v}}" class="ui label">{{printf "v%d" $v}}</a>
 		{{end}}
 	</div>
 </div>

--- a/cmd/roi/tmpl/update-version.html
+++ b/cmd/roi/tmpl/update-version.html
@@ -6,16 +6,16 @@
 	<h2 class="ui dividing header">버전 수정</h2>
 	<form method="post" class="ui form">
 		<div class="field disabled"><label>프로젝트</label>
-			<input type="text" name="project_id" value="{{.Version.ProjectID}}"/>
+			<input type="text" name="project_id" value="{{.Version.Project}}"/>
 		</div>
 		<div class="field disabled"><label>아이디</label>
-			<input type="text" name="shot_id" value="{{.Version.ShotID}}"/>
+			<input type="text" name="shot_id" value="{{.Version.Shot}}"/>
 		</div>
 		<div class="field disabled"><label>태스크</label>
-			<input type="text" name="task_name" value="{{.Version.TaskName}}"/>
+			<input type="text" name="task_name" value="{{.Version.Task}}"/>
 		</div>
 		<div class="field disabled"><label>번호</label>
-			<input type="text" name="num" value="{{.Version.Num}}"/>
+			<input type="text" name="num" value="{{.Version.Version}}"/>
 		</div>
 		<div class="field"><label>파일</label>
 			<input type="text" name="output_files" value="{{join .Version.OutputFiles ", "}}"/>

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -169,9 +169,9 @@ func addVersionHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	o := &roi.Version{
-		ProjectID: prj,
-		ShotID:    shot,
-		TaskName:  task,
+		Project: prj,
+		Shot:    shot,
+		Task:    task,
 	}
 	err = roi.AddVersion(db, prj, shot, task, o)
 	if err != nil {

--- a/cmd/roishot/main.go
+++ b/cmd/roishot/main.go
@@ -38,7 +38,7 @@ func main() {
 		fname := filepath.Base(f)
 		prj = strings.TrimSuffix(fname, filepath.Ext(fname))
 	}
-	if !roi.IsValidProjectID(prj) {
+	if !roi.IsValidProject(prj) {
 		fmt.Fprintln(os.Stderr, prj, "이 프로젝트 아이디로 적절치 않습니다.")
 		os.Exit(1)
 	}

--- a/project_test.go
+++ b/project_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var testProject = &Project{
-	ID:            "TEST",
+	Project:       "TEST",
 	Name:          "테스트 프로젝트",
 	Status:        "waiting",
 	Client:        "레이지 픽처스",
@@ -36,18 +36,18 @@ func TestProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not add project to projects table: %s", err)
 	}
-	exist, err := ProjectExist(db, want.ID)
+	exist, err := ProjectExist(db, want.Project)
 	if err != nil {
 		t.Fatalf("could not check project existence from projects table: %s", err)
 	}
 	if !exist {
-		t.Fatalf("project not found from projects table: %s", want.ID)
+		t.Fatalf("project not found from projects table: %s", want.Project)
 	}
-	got, err := GetProject(db, want.ID)
+	got, err := GetProject(db, want.Project)
 	if err != nil {
 		t.Fatalf("could not get project from projects table: %s", err)
 	}
-	if !IsValidProjectID(got.ID) {
+	if !IsValidProject(got.Project) {
 		if err != nil {
 			t.Fatalf("find project with invalid id from projects table: %s", err)
 		}
@@ -60,11 +60,11 @@ func TestProject(t *testing.T) {
 	if !reflect.DeepEqual(gotAll, wantAll) {
 		t.Fatalf("got: %v, want: %v", got, want)
 	}
-	err = UpdateProject(db, want.ID, UpdateProjectParam{})
+	err = UpdateProject(db, want.Project, UpdateProjectParam{})
 	if err != nil {
 		t.Fatalf("could not clear(update) project: %s", err)
 	}
-	err = DeleteProject(db, want.ID)
+	err = DeleteProject(db, want.Project)
 	if err != nil {
 		t.Fatalf("could not delete project: %s", err)
 	}

--- a/shot_test.go
+++ b/shot_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 var testShotA = &Shot{
-	ID:            "CG_0010",
-	ProjectID:     testProject.ID,
+	Project:       testProject.Project,
+	Shot:          "CG_0010",
 	Status:        ShotInProgress,
 	EditOrder:     10,
 	Description:   "방에 우두커니 혼자 않아 있는 로이.",
@@ -21,8 +21,8 @@ var testShotA = &Shot{
 }
 
 var testShotB = &Shot{
-	ID:            "CG_0020",
-	ProjectID:     testProject.ID,
+	Shot:          "CG_0020",
+	Project:       testProject.Project,
 	Status:        ShotWaiting,
 	EditOrder:     20,
 	Description:   "고개를 돌려 창문 밖을 바라본다.",
@@ -33,8 +33,8 @@ var testShotB = &Shot{
 	Tags:          []string{"로이", "창문"},
 }
 var testShotC = &Shot{
-	ID:            "CG_0030",
-	ProjectID:     testProject.ID,
+	Shot:          "CG_0030",
+	Project:       testProject.Project,
 	Status:        ShotWaiting,
 	EditOrder:     30,
 	Description:   "쓸쓸해 보이는 가로등",
@@ -60,22 +60,22 @@ func TestShot(t *testing.T) {
 	}
 
 	for _, s := range want {
-		err = AddShot(db, testProject.ID, s)
+		err = AddShot(db, testProject.Project, s)
 		if err != nil {
 			t.Fatalf("could not add shot to shots table: %s", err)
 		}
-		exist, err := ShotExist(db, testProject.ID, s.ID)
+		exist, err := ShotExist(db, testProject.Project, s.Shot)
 		if err != nil {
 			t.Fatalf("could not check shot existence from shots table: %s", err)
 		}
 		if !exist {
-			t.Fatalf("shot not found from shots table: %s", s.ID)
+			t.Fatalf("shot not found from shots table: %s", s.Shot)
 		}
-		got, err := GetShot(db, testProject.ID, s.ID)
+		got, err := GetShot(db, testProject.Project, s.Shot)
 		if err != nil {
 			t.Fatalf("could not get shot from shots table: %s", err)
 		}
-		if !IsValidShotID(got.ID) {
+		if !IsValidShot(got.Shot) {
 			if err != nil {
 				t.Fatalf("find shot with invalid id from shots table: %s", err)
 			}
@@ -85,7 +85,7 @@ func TestShot(t *testing.T) {
 		}
 	}
 
-	got, err := SearchShots(db, testProject.ID, "", "", "", "", "", time.Time{})
+	got, err := SearchShots(db, testProject.Project, "", "", "", "", "", time.Time{})
 	if err != nil {
 		t.Fatalf("could not search shots from shots table: %s", err)
 	}
@@ -93,7 +93,7 @@ func TestShot(t *testing.T) {
 		t.Fatalf("got: %v, want: %v", got, want)
 	}
 
-	got, err = SearchShots(db, testProject.ID, "CG_0010", "", "", "", "", time.Time{})
+	got, err = SearchShots(db, testProject.Project, "CG_0010", "", "", "", "", time.Time{})
 	if err != nil {
 		t.Fatalf("could not search shots from shots table: %s", err)
 	}
@@ -101,7 +101,7 @@ func TestShot(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got: %v, want: %v", got, want)
 	}
-	got, err = SearchShots(db, testProject.ID, "", "로이", "", "", "", time.Time{})
+	got, err = SearchShots(db, testProject.Project, "", "로이", "", "", "", time.Time{})
 	if err != nil {
 		t.Fatalf("could not search shots from shots table: %s", err)
 	}
@@ -111,17 +111,17 @@ func TestShot(t *testing.T) {
 	}
 
 	for _, s := range want {
-		err = UpdateShot(db, testProject.ID, s.ID, UpdateShotParam{Status: ShotWaiting})
+		err = UpdateShot(db, testProject.Project, s.Shot, UpdateShotParam{Status: ShotWaiting})
 		if err != nil {
 			t.Fatalf("could not clear(update) shot: %s", err)
 		}
-		err = DeleteShot(db, testProject.ID, s.ID)
+		err = DeleteShot(db, testProject.Project, s.Shot)
 		if err != nil {
 			t.Fatalf("could not delete shot from shots table: %s", err)
 		}
 	}
 
-	err = DeleteProject(db, testProject.ID)
+	err = DeleteProject(db, testProject.Project)
 	if err != nil {
 		t.Fatalf("could not delete project: %s", err)
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 var testTaskA = &Task{
-	ProjectID: testProject.ID,
-	ShotID:    testShotA.ID,
-	Name:      "fx_fire",
-	Status:    TaskNotSet,
-	Assignee:  "kybin",
+	Project:  testShotA.Project,
+	Shot:     testShotA.Shot,
+	Task:     "fx_fire",
+	Status:   TaskNotSet,
+	Assignee: "kybin",
 }
 
 func TestTask(t *testing.T) {
@@ -21,16 +21,15 @@ func TestTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not add project: %s", err)
 	}
-	err = AddShot(db, testProject.ID, testShotA)
+	err = AddShot(db, testTaskA.Project, testShotA)
 	if err != nil {
 		t.Fatalf("could not add shot: %s", err)
 	}
-
-	err = AddTask(db, testProject.ID, testShotA.ID, testTaskA)
+	err = AddTask(db, testTaskA.Project, testTaskA.Shot, testTaskA)
 	if err != nil {
 		t.Fatalf("could not add task: %s", err)
 	}
-	exist, err := TaskExist(db, testProject.ID, testShotA.ID, testTaskA.Name)
+	exist, err := TaskExist(db, testTaskA.Project, testTaskA.Shot, testTaskA.Task)
 	if err != nil {
 		t.Fatalf("could not check task exist: %s", err)
 	}
@@ -45,11 +44,11 @@ func TestTask(t *testing.T) {
 	if len(tasks) != 0 {
 		t.Fatalf("invalid number of user tasks: want 0, got %d", len(tasks))
 	}
-	err = DeleteTask(db, testProject.ID, testShotA.ID, testTaskA.Name)
+	err = DeleteTask(db, testTaskA.Project, testTaskA.Shot, testTaskA.Task)
 	if err != nil {
 		t.Fatalf("could not delete task: %s", err)
 	}
-	exist, err = TaskExist(db, testProject.ID, testShotA.ID, testTaskA.Name)
+	exist, err = TaskExist(db, testTaskA.Project, testTaskA.Shot, testTaskA.Task)
 	if err != nil {
 		t.Fatalf("could not check task exist: %s", err)
 	}
@@ -57,11 +56,11 @@ func TestTask(t *testing.T) {
 		t.Fatalf("deleted task exist")
 	}
 
-	err = DeleteShot(db, testProject.ID, testShotA.ID)
+	err = DeleteShot(db, testTaskA.Project, testTaskA.Shot)
 	if err != nil {
 		t.Fatalf("could not delete shot: %s", err)
 	}
-	err = DeleteProject(db, testProject.ID)
+	err = DeleteProject(db, testTaskA.Project)
 	if err != nil {
 		t.Fatalf("could not delete project: %s", err)
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 var testVersionA = &Version{
-	ProjectID: testProject.ID,
-	ShotID:    testShotA.ID,
-	TaskName:  testTaskA.Name,
+	Project: testProject.Project,
+	Shot:    testShotA.Shot,
+	Task:    testTaskA.Task,
 
-	Num:         0, // DB에 Version을 추가할 때는 Num이 지정되어 있으면 안된다.
+	Version:     0, // DB에 Version을 추가할 때는 Version이 지정되어 있으면 안된다.
 	OutputFiles: []string{"/project/test/FOO_0010/scene/test.v001.abc"},
 	Images: []string{
 		"/project/test/FOO_0010/render/test.v001.0001.jpg",
@@ -32,20 +32,20 @@ func TestVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not add project: %v", err)
 	}
-	err = AddShot(db, testProject.ID, testShotA)
+	err = AddShot(db, testVersionA.Project, testShotA)
 	if err != nil {
 		t.Fatalf("could not add shot: %v", err)
 	}
-	err = AddTask(db, testProject.ID, testShotA.ID, testTaskA)
+	err = AddTask(db, testVersionA.Project, testVersionA.Shot, testTaskA)
 	if err != nil {
 		t.Fatalf("could not add task: %v", err)
 	}
 
-	err = AddVersion(db, testProject.ID, testShotA.ID, testTaskA.Name, testVersionA)
+	err = AddVersion(db, testVersionA.Project, testVersionA.Shot, testVersionA.Task, testVersionA)
 	if err != nil {
 		t.Fatalf("could not add version: %v", err)
 	}
-	exist, err := VersionExist(db, testProject.ID, testShotA.ID, testTaskA.Name, testVersionA.Num)
+	exist, err := VersionExist(db, testVersionA.Project, testVersionA.Shot, testVersionA.Task, testVersionA.Version)
 	if err != nil {
 		t.Fatalf("could not check version exist: %v", err)
 	}
@@ -53,19 +53,19 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("added version not exist")
 	}
 	want := testVersionA
-	want.Num = 1 // DB에 들어가면서 버전 번호가 추가되어야 한다.
-	got, err := GetVersion(db, testProject.ID, testShotA.ID, testTaskA.Name, want.Num)
+	want.Version = 1 // DB에 들어가면서 버전 번호가 추가되어야 한다.
+	got, err := GetVersion(db, testVersionA.Project, testVersionA.Shot, testVersionA.Task, want.Version)
 	if err != nil {
 		t.Fatalf("could not get version: %v", err)
 	}
-	shotVersions, err := ShotVersions(db, testProject.ID, testShotA.ID)
+	shotVersions, err := ShotVersions(db, testVersionA.Project, testVersionA.Shot)
 	if err != nil {
 		t.Fatalf("could not get versions of shot: %v", err)
 	}
 	if len(shotVersions) != 1 {
 		t.Fatalf("shot should have 1 version at this time.")
 	}
-	taskVersions, err := TaskVersions(db, testProject.ID, testShotA.ID, testTaskA.Name)
+	taskVersions, err := TaskVersions(db, testVersionA.Project, testVersionA.Shot, testVersionA.Task)
 	if err != nil {
 		t.Fatalf("could not get versions of task: %v", err)
 	}
@@ -75,15 +75,15 @@ func TestVersion(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("added version is not expected: got %v, want %v", got, want)
 	}
-	err = UpdateVersion(db, testProject.ID, testShotA.ID, testTaskA.Name, testVersionA.Num, UpdateVersionParam{})
+	err = UpdateVersion(db, testVersionA.Project, testVersionA.Shot, testVersionA.Task, testVersionA.Version, UpdateVersionParam{})
 	if err != nil {
 		t.Fatalf("could not clear(update) version: %v", err)
 	}
-	err = DeleteVersion(db, testProject.ID, testShotA.ID, testTaskA.Name, testVersionA.Num)
+	err = DeleteVersion(db, testVersionA.Project, testVersionA.Shot, testVersionA.Task, testVersionA.Version)
 	if err != nil {
 		t.Fatalf("could not delete version: %v", err)
 	}
-	exist, err = VersionExist(db, testProject.ID, testShotA.ID, testTaskA.Name, testVersionA.Num)
+	exist, err = VersionExist(db, testVersionA.Project, testVersionA.Shot, testVersionA.Task, testVersionA.Version)
 	if err != nil {
 		t.Fatalf("could not check version exist: %v", err)
 	}
@@ -91,15 +91,15 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("deleted version exist")
 	}
 
-	err = DeleteTask(db, testProject.ID, testShotA.ID, testTaskA.Name)
+	err = DeleteTask(db, testVersionA.Project, testVersionA.Shot, testVersionA.Task)
 	if err != nil {
 		t.Fatalf("could not delete task: %v", err)
 	}
-	err = DeleteShot(db, testProject.ID, testShotA.ID)
+	err = DeleteShot(db, testVersionA.Project, testVersionA.Shot)
 	if err != nil {
 		t.Fatalf("could not delete shot: %v", err)
 	}
-	err = DeleteProject(db, testProject.ID)
+	err = DeleteProject(db, testVersionA.Project)
 	if err != nil {
 		t.Fatalf("could not delete project: %v", err)
 	}


### PR DESCRIPTION
예를 들어 다음처럼 변경되었다.

Project.ID => Project.Project
Shot.ID => Shot.Shot
Task.Name => Task.Task

이렇게 바꾼 이유는 하위 구조에서 상위 구조와 같은 키 이름을 쓰기
위함이다.

아래 처럼 Project 하위 구조에는 Project라는 키가 존재한다.

Project.Project
Shot.Project
Task.Project
Version.Project

마찬가지로 모든 Shot 하위 구조에는 Shot이라는 키가 존재한다.

Shot.Shot
Task.Shot
Version.Shot

각 스트럭트의 관점에서는 예쁜 변화는 아니지만 전체 구조를
통일시켜서 코드를 더 알아보기 쉽게 해준다는 장점이 있다.