### PR TITLE
cmd/roi: 내 페이지의 날짜 처리에 문자열 사용

### DIFF
--- a/cmd/roi/root_handler.go
+++ b/cmd/roi/root_handler.go
@@ -49,21 +49,22 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 		tid := t.Project + "." + t.Shot + "." + t.Task
 		taskFromID[tid] = t
 	}
-	tasksOfDay := make(map[time.Time][]string, 28)
+	tasksOfDay := make(map[string][]string, 28)
 	for _, t := range tasks {
-		if tasksOfDay[t.DueDate] == nil {
-			tasksOfDay[t.DueDate] = make([]string, 0)
+		due := stringFromDate(t.DueDate)
+		if tasksOfDay[due] == nil {
+			tasksOfDay[due] = make([]string, 0)
 		}
 		tid := t.Project + "." + t.Shot + "." + t.Task
-		tasksOfDay[t.DueDate] = append(tasksOfDay[t.DueDate], tid)
+		tasksOfDay[due] = append(tasksOfDay[due], tid)
 	}
 	// 앞으로 4주에 대한 태스크 정보를 보인다.
 	// 총 기간이나 단위는 추후 설정할 수 있도록 할 것.
-	timeline := make([]time.Time, 28)
+	timeline := make([]string, 28)
 	y, m, d := time.Now().Date()
-	today := time.Date(y, m, d, 23, 59, 59, 0, time.Local).UTC()
+	today := time.Date(y, m, d, 0, 0, 0, 0, time.Local)
 	for i := range timeline {
-		timeline[i] = today.Add(time.Duration(i) * 24 * time.Hour)
+		timeline[i] = stringFromDate(today.Add(time.Duration(i) * 24 * time.Hour))
 	}
 	numTasks := make(map[string]map[roi.TaskStatus]int)
 	for _, t := range tasks {
@@ -74,10 +75,10 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	recipt := struct {
 		LoggedInUser  string
-		Timeline      []time.Time
+		Timeline      []string
 		NumTasks      map[string]map[roi.TaskStatus]int
 		TaskFromID    map[string]*roi.Task
-		TasksOfDay    map[time.Time][]string
+		TasksOfDay    map[string][]string
 		AllTaskStatus []roi.TaskStatus
 	}{
 		LoggedInUser:  session["userid"],

--- a/cmd/roi/template.go
+++ b/cmd/roi/template.go
@@ -58,7 +58,11 @@ func hasThumbnail(prj, shot string) bool {
 }
 
 // isSunday는 해당일이 일요일인지를 검사한다.
-func isSunday(t time.Time) bool {
+func isSunday(day string) bool {
+	t, err := time.ParseInLocation("2006-01-02", day, time.Local)
+	if err != nil {
+		return false
+	}
 	wd := t.Weekday()
 	return wd == time.Sunday
 }

--- a/cmd/roi/tmpl/index.html
+++ b/cmd/roi/tmpl/index.html
@@ -13,7 +13,7 @@
 		{{$bg = dayColorInTimeline $numTasks}}
 	{{end}}
 	<!-- 날짜 타일 -->
-	<div style="flex:1;height:0.9rem;margin:4px 1px;border-radius:1px;background-color:{{$bg}};font-size:0.7rem;display:flex;align-items:center;justify-content:center;cursor:pointer;" onclick="showTasks({{stringFromDate $day}})">
+	<div style="flex:1;height:0.9rem;margin:4px 1px;border-radius:1px;background-color:{{$bg}};font-size:0.7rem;display:flex;align-items:center;justify-content:center;cursor:pointer;" onclick="showTasks({{$day}})">
 		{{if ne $numTasks 0}}
 			{{$numTasks}}
 		{{end}}
@@ -67,7 +67,7 @@ let taskFromID = {
 
 let tasksOfDay = {
 	{{range $day, $tasks := $.TasksOfDay -}}
-	"{{stringFromDate $day}}": [
+	"{{$day}}": [
 		{{range $id := $tasks -}}
 		"{{$id}}",
 		{{end}}
@@ -87,12 +87,12 @@ function showTasks(day) {
 	for (i = 0; i < els.length; i++) {
 		els[i].innerHTML = "";
 	}
-	let tasks = [];
+	tasks = [];
 	if (day == "") {
 		for (let id in taskFromID) {
 			tasks.push(id);
 		}
-	} else {
+	} else if (tasksOfDay[day]) {
 		tasks = tasksOfDay[day];
 	}
 	tasks.sort();


### PR DESCRIPTION
map의 키 타입으로 시간을 문자열 대신 사용했던건 디버깅 측면에서
나쁜 선택이었던것 같다.