### PR TITLE
cmd/roi: fields 함수의 구분자 인수를 없애 단순화 함

### DIFF
--- a/cmd/roi/api.go
+++ b/cmd/roi/api.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/studio2l/roi"
@@ -65,7 +64,7 @@ func addShowApiHandler(w http.ResponseWriter, r *http.Request) {
 		apiBadRequest(w, fmt.Errorf("show '%s' already exists", show))
 		return
 	}
-	tasks := fields(r.Form.Get("default_tasks"), ",")
+	tasks := fields(r.Form.Get("default_tasks"))
 	p := &roi.Show{
 		Show:         show,
 		DefaultTasks: tasks,
@@ -156,7 +155,7 @@ func addShotApiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		duration = int(f)
 	}
-	tasks := fields(r.Form.Get("working_tasks"), ",")
+	tasks := fields(r.Form.Get("working_tasks"))
 	if len(tasks) == 0 {
 		p, err := roi.GetShow(db, show)
 		if err != nil {
@@ -176,7 +175,7 @@ func addShotApiHandler(w http.ResponseWriter, r *http.Request) {
 		TimecodeIn:    r.PostFormValue("timecode_in"),
 		TimecodeOut:   r.PostFormValue("timecode_out"),
 		Duration:      duration,
-		Tags:          strings.Split(r.PostFormValue("tags"), ","),
+		Tags:          fields(r.PostFormValue("tags")),
 		WorkingTasks:  tasks,
 	}
 	err = roi.AddShot(db, show, s)

--- a/cmd/roi/shot_handler.go
+++ b/cmd/roi/shot_handler.go
@@ -91,7 +91,7 @@ func addShotHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "shot '%s' already exist", http.StatusBadRequest)
 			return
 		}
-		tasks := fields(r.Form.Get("working_tasks"), ",")
+		tasks := fields(r.Form.Get("working_tasks"))
 		s := &roi.Shot{
 			Shot:          shot,
 			Show:          show,
@@ -102,7 +102,7 @@ func addShotHandler(w http.ResponseWriter, r *http.Request) {
 			TimecodeIn:    r.Form.Get("timecode_in"),
 			TimecodeOut:   r.Form.Get("timecode_out"),
 			Duration:      atoi(r.Form.Get("duration")),
-			Tags:          fields(r.Form.Get("tags"), ","),
+			Tags:          fields(r.Form.Get("tags")),
 			WorkingTasks:  tasks,
 		}
 		err = roi.AddShot(db, show, s)
@@ -198,7 +198,7 @@ func updateShotHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("shot '%s' not exist", shot), http.StatusBadRequest)
 			return
 		}
-		tasks := fields(r.Form.Get("working_tasks"), ",")
+		tasks := fields(r.Form.Get("working_tasks"))
 		tforms, err := parseTimeForms(r.Form, "due_date")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -211,7 +211,7 @@ func updateShotHandler(w http.ResponseWriter, r *http.Request) {
 			TimecodeIn:    r.Form.Get("timecode_in"),
 			TimecodeOut:   r.Form.Get("timecode_out"),
 			Duration:      atoi(r.Form.Get("duration")),
-			Tags:          fields(r.Form.Get("tags"), ","),
+			Tags:          fields(r.Form.Get("tags")),
 			WorkingTasks:  tasks,
 			DueDate:       tforms["due_date"],
 		}

--- a/cmd/roi/show_handler.go
+++ b/cmd/roi/show_handler.go
@@ -115,7 +115,7 @@ func addShowHandler(w http.ResponseWriter, r *http.Request) {
 			VFXDueDate:    timeForms["vfx_due_date"],
 			OutputSize:    r.Form.Get("output_size"),
 			ViewLUT:       r.Form.Get("view_lut"),
-			DefaultTasks:  fields(r.Form.Get("default_tasks"), ","),
+			DefaultTasks:  fields(r.Form.Get("default_tasks")),
 		}
 		err = roi.AddShow(db, p)
 		if err != nil {
@@ -205,7 +205,7 @@ func updateShowHandler(w http.ResponseWriter, r *http.Request) {
 			VFXDueDate:    timeForms["vfx_due_date"],
 			OutputSize:    r.Form.Get("output_size"),
 			ViewLUT:       r.Form.Get("view_lut"),
-			DefaultTasks:  fields(r.Form.Get("default_tasks"), ","),
+			DefaultTasks:  fields(r.Form.Get("default_tasks")),
 		}
 		err = roi.UpdateShow(db, id, upd)
 		if err != nil {

--- a/cmd/roi/site_handler.go
+++ b/cmd/roi/site_handler.go
@@ -22,12 +22,12 @@ func siteHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "POST" {
 		r.ParseForm()
 		s := &roi.Site{
-			VFXSupervisors:  fields(r.Form.Get("vfx_supervisors"), ","),
-			VFXProducers:    fields(r.Form.Get("vfx_producers"), ","),
-			CGSupervisors:   fields(r.Form.Get("cg_supervisors"), ","),
-			ProjectManagers: fields(r.Form.Get("project_managers"), ","),
-			Tasks:           fields(r.Form.Get("tasks"), ","),
-			Leads:           fields(r.Form.Get("leads"), ","),
+			VFXSupervisors:  fields(r.Form.Get("vfx_supervisors")),
+			VFXProducers:    fields(r.Form.Get("vfx_producers")),
+			CGSupervisors:   fields(r.Form.Get("cg_supervisors")),
+			ProjectManagers: fields(r.Form.Get("project_managers")),
+			Tasks:           fields(r.Form.Get("tasks")),
+			Leads:           fields(r.Form.Get("leads")),
 		}
 		err = roi.UpdateSite(db, s)
 		if err != nil {

--- a/cmd/roi/str.go
+++ b/cmd/roi/str.go
@@ -5,15 +5,15 @@ import (
 	"strings"
 )
 
-// fields는 원하는 문자열로 다른 문자열을 잘라 슬라이스로 반환한다.
+// fields는 문자열을 콤마로 잘라 슬라이스로 반환한다.
 // 잘린 문자열 양 옆의 빈 문자열은 함께 지워진다.
 // 혹시 필드가 빈 문자열이라면 그 항목은 포함되지 않는다.
 //
-// 예) fields("a, b, c, ", ",") => []string{"a", "b", "c"}
-func fields(s, sep string) []string {
-	rawFs := strings.Split(s, sep)
-	fs := make([]string, 0, len(rawFs))
-	for _, f := range rawFs {
+// 예) fields("a, b, c,, ") => []string{"a", "b", "c"}
+func fields(s string) []string {
+	ss := strings.Split(s, ",")
+	fs := make([]string, 0, len(ss))
+	for _, f := range ss {
 		f = strings.TrimSpace(f)
 		if f != "" {
 			fs = append(fs, f)

--- a/cmd/roi/str_test.go
+++ b/cmd/roi/str_test.go
@@ -13,17 +13,15 @@ func TestFields(t *testing.T) {
 	}{
 		{
 			s:    ", a, b, c, ",
-			sep:  ",",
 			want: []string{"a", "b", "c"},
 		},
 		{
 			s:    "a,  , , b, , c, ",
-			sep:  ",",
 			want: []string{"a", "b", "c"},
 		},
 	}
 	for _, c := range cases {
-		got := fields(c.s, c.sep)
+		got := fields(c.s)
 		if !reflect.DeepEqual(got, c.want) {
 			t.Fatalf("fleids: got: %v, want: %v", got, c.want)
 		}

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -72,7 +72,7 @@ func addVersionHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		files := fields(r.Form.Get("output_files"), ",")
+		files := fields(r.Form.Get("output_files"))
 		work_file := r.Form.Get("work_file")
 		mov := r.Form.Get("mov")
 		created, err := timeFromString(r.Form.Get("created"))
@@ -224,8 +224,8 @@ func updateVersionHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		u := roi.UpdateVersionParam{
-			OutputFiles: fields(r.Form.Get("output_files"), ","),
-			Images:      fields(r.Form.Get("images"), ","),
+			OutputFiles: fields(r.Form.Get("output_files")),
+			Images:      fields(r.Form.Get("images")),
 			Mov:         r.Form.Get("mov"),
 			WorkFile:    r.Form.Get("work_file"),
 			Created:     timeForms["created"],


### PR DESCRIPTION
구분자는 항상 콤마이고 다른 문자를 쓰지 않을 생각임.