### PR TITLE
http 에러 처리 방식 변경

### DIFF
--- a/cmd/roi/error.go
+++ b/cmd/roi/error.go
@@ -1,19 +1,27 @@
 package main
 
-import "net/http"
+import (
+	"log"
+	"net/http"
+)
 
 type httpError struct {
-	err  string
+	msg  string
 	code int
 }
 
 func (e httpError) Error() string {
-	return e.err
+	return e.msg
 }
 
-func responseError(w http.ResponseWriter, err error) {
+func handleError(w http.ResponseWriter, err error) {
 	if e, ok := err.(httpError); ok {
-		http.Error(w, e.err, e.code)
+		if e.code == http.StatusInternalServerError {
+			log.Print(e.msg)
+			http.Error(w, "internal error", e.code)
+			return
+		}
+		http.Error(w, e.msg, e.code)
 		return
 	}
 	http.Error(w, err.Error(), http.StatusBadRequest)

--- a/cmd/roi/error.go
+++ b/cmd/roi/error.go
@@ -1,0 +1,20 @@
+package main
+
+import "net/http"
+
+type httpError struct {
+	err  string
+	code int
+}
+
+func (e httpError) Error() string {
+	return e.err
+}
+
+func responseError(w http.ResponseWriter, err error) {
+	if e, ok := err.(httpError); ok {
+		http.Error(w, e.err, e.code)
+		return
+	}
+	http.Error(w, err.Error(), http.StatusBadRequest)
+}

--- a/cmd/roi/handler.go
+++ b/cmd/roi/handler.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/studio2l/roi"
+)
+
+func mustFields(r *http.Request, keys ...string) error {
+	for _, k := range keys {
+		if r.FormValue(k) == "" {
+			return httpError{msg: fmt.Sprintf("form field not found: %s", k), code: http.StatusBadRequest}
+		}
+	}
+	return nil
+}
+
+func getSessionUser(r *http.Request) (*roi.User, error) {
+	session, err := getSession(r)
+	if err != nil {
+		return nil, httpError{msg: "could not get session", code: http.StatusUnauthorized}
+	}
+	user := session["userid"]
+	u, err := roi.GetUser(DB, user)
+	if err != nil {
+		return nil, httpError{msg: "could not get user information", code: http.StatusInternalServerError}
+	}
+	if u == nil {
+		return nil, httpError{msg: fmt.Sprintf("user not exist: %s", user), code: http.StatusBadRequest}
+	}
+	return u, nil
+}
+
+func saveFormFile(r *http.Request, field string, dst string) error {
+	f, fi, err := r.FormFile(field)
+	if err != nil {
+		if err == http.ErrMissingFile {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+	if fi.Size > (32 << 20) {
+		return httpError{msg: fmt.Sprintf("mov: file size too big (got %dMB, maximum 32MB)", fi.Size>>20), code: http.StatusBadRequest}
+	}
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return httpError{msg: "could not read file data", code: http.StatusInternalServerError}
+	}
+	err = os.MkdirAll(filepath.Dir(dst), 0755)
+	if err != nil {
+		return httpError{msg: fmt.Sprintf("could not create directory: %v", err), code: http.StatusInternalServerError}
+	}
+	err = ioutil.WriteFile(dst, data, 0755)
+	if err != nil {
+		return httpError{msg: fmt.Sprintf("could not save file: %v", err), code: http.StatusInternalServerError}
+	}
+	return nil
+}

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -2,150 +2,76 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/studio2l/roi"
 )
 
 func addVersionHandler(w http.ResponseWriter, r *http.Request) {
-	session, err := getSession(r)
+	u, err := getSessionUser(r)
 	if err != nil {
-		http.Error(w, "could not get session", http.StatusUnauthorized)
+		handleError(w, err)
 		clearSession(w)
 		return
 	}
-	u, err := roi.GetUser(DB, session["userid"])
+	err = mustFields(r, "show", "shot", "task")
 	if err != nil {
-		http.Error(w, "could not get user information", http.StatusInternalServerError)
-		clearSession(w)
+		handleError(w, err)
 		return
 	}
-	if u == nil {
-		http.Error(w, "user not exist", http.StatusBadRequest)
-		clearSession(w)
-		return
-	}
-	if false {
-		// 할일: 오직 어드민, 프로젝트 슈퍼바이저, 프로젝트 매니저, CG 슈퍼바이저만
-		// 이 정보를 수정할 수 있도록 하기.
-		_ = u
-	}
-	r.ParseForm()
-	show := r.Form.Get("show")
-	if show == "" {
-		http.Error(w, "need 'show'", http.StatusBadRequest)
-		return
-	}
-	exist, err := roi.ShowExist(DB, show)
-	if err != nil {
-		log.Print(err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if !exist {
-		http.Error(w, fmt.Sprintf("show '%s' not exist", show), http.StatusBadRequest)
-		return
-	}
-	shot := r.Form.Get("shot")
-	if shot == "" {
-		http.Error(w, "need 'shot'", http.StatusBadRequest)
-		return
-	}
-	task := r.Form.Get("task")
-	if task == "" {
-		http.Error(w, "need 'task'", http.StatusBadRequest)
-		return
-	}
-
+	show := r.FormValue("show")
+	shot := r.FormValue("shot")
+	task := r.FormValue("task")
+	taskID := fmt.Sprintf("%s.%s.%s", show, shot, task)
 	if r.Method == "POST" {
+		err := mustFields(r, "version")
+		if err != nil {
+			handleError(w, err)
+		}
+		version := r.FormValue("version")
 		err = r.ParseMultipartForm(1 << 20)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			handleError(w, httpError{msg: err.Error(), code: http.StatusBadRequest})
 			return
 		}
-		version := r.Form.Get("version")
-		if version == "" {
-			http.Error(w, "need 'version'", http.StatusBadRequest)
-			return
-		}
-
-		files := fields(r.Form.Get("output_files"))
-		work_file := r.Form.Get("work_file")
-		created, err := timeFromString(r.Form.Get("created"))
+		timeForms, err := parseTimeForms(r.Form, "created")
 		if err != nil {
-			http.Error(w, fmt.Sprintf("invalid 'create' field: %v", r.Form.Get("created")), http.StatusBadRequest)
+			handleError(w, err)
 			return
 		}
-		taskID := fmt.Sprintf("%s.%s.%s", show, shot, task)
 		t, err := roi.GetTask(DB, show, shot, task)
 		if err != nil {
-			log.Printf("could not get task '%s': %v", taskID, err)
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			handleError(w, httpError{msg: err.Error(), code: http.StatusInternalServerError})
 			return
 		}
 		if t == nil {
-			http.Error(w, fmt.Sprintf("task '%s' not exist", taskID), http.StatusBadRequest)
+			handleError(w, httpError{msg: fmt.Sprintf("task not found: %s", taskID), code: http.StatusBadRequest})
 			return
 		}
-		src, mov, err := r.FormFile("mov")
+		mov := fmt.Sprintf("data/show/%s/%s/%s/%s/1.mov", show, shot, task, version)
+		err = saveFormFile(r, "mov", mov)
 		if err != nil {
-			if err != http.ErrMissingFile {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		} else {
-			defer src.Close()
-			if mov.Size > (32 << 20) {
-				http.Error(w, fmt.Sprintf("mov: file size too big (got %dMB, maximum 32MB)", mov.Size>>20), http.StatusBadRequest)
-				return
-			}
-			data, err := ioutil.ReadAll(src)
-			if err != nil {
-				http.Error(w, "could not get mov file data", http.StatusBadRequest)
-				return
-			}
-			err = os.MkdirAll(fmt.Sprintf("data/show/%s/%s/%s/%s", show, shot, task, version), 0755)
-			if err != nil {
-				log.Printf("could not create mov directory: %v", err)
-				http.Error(w, "internal error", http.StatusInternalServerError)
-				return
-			}
-			dst := fmt.Sprintf("data/show/%s/%s/%s/%s/1.mov", show, shot, task, version)
-			err = ioutil.WriteFile(dst, data, 0755)
-			if err != nil {
-				log.Printf("could not save mov file data: %v", err)
-				http.Error(w, "internal error", http.StatusInternalServerError)
-				return
-			}
+			handleError(w, err)
+			return
 		}
 		v := &roi.Version{
 			Show:        show,
 			Shot:        shot,
 			Task:        task,
 			Version:     version,
-			OutputFiles: files,
-			WorkFile:    work_file,
-			Created:     created,
+			OutputFiles: fields(r.FormValue("output_files")),
+			WorkFile:    r.FormValue("work_file"),
+			Created:     timeForms["create"],
 		}
 		err = roi.AddVersion(DB, show, shot, task, v)
 		if err != nil {
-			log.Printf("could not add version to task '%s': %v", taskID, err)
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			handleError(w, httpError{msg: fmt.Sprintf("could not add version to task '%s': %v", taskID, err), code: http.StatusInternalServerError})
 			return
 		}
 		http.Redirect(w, r, fmt.Sprintf("/update-version?show=%s&shot=%s&task=%s&version=%s", show, shot, task, version), http.StatusSeeOther)
 		return
-	}
-	now := time.Now()
-	v := &roi.Version{
-		Show:    show,
-		Shot:    shot,
-		Task:    task,
-		Created: now,
 	}
 	recipe := struct {
 		PageType     string
@@ -153,8 +79,13 @@ func addVersionHandler(w http.ResponseWriter, r *http.Request) {
 		Version      *roi.Version
 	}{
 		PageType:     "add",
-		LoggedInUser: session["userid"],
-		Version:      v,
+		LoggedInUser: u.ID,
+		Version: &roi.Version{
+			Show:    show,
+			Shot:    shot,
+			Task:    task,
+			Created: time.Now(),
+		},
 	}
 	err = executeTemplate(w, "update-version.html", recipe)
 	if err != nil {
@@ -164,129 +95,57 @@ func addVersionHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func updateVersionHandler(w http.ResponseWriter, r *http.Request) {
-	session, err := getSession(r)
+	u, err := getSessionUser(r)
 	if err != nil {
-		http.Error(w, "could not get session", http.StatusUnauthorized)
+		handleError(w, err)
 		clearSession(w)
 		return
 	}
-	u, err := roi.GetUser(DB, session["userid"])
+	err = mustFields(r, "show", "shot", "task", "version")
 	if err != nil {
-		http.Error(w, "could not get user information", http.StatusInternalServerError)
-		clearSession(w)
+		handleError(w, err)
 		return
 	}
-	if u == nil {
-		http.Error(w, "user not exist", http.StatusBadRequest)
-		clearSession(w)
-		return
-	}
-	if false {
-		// 할일: 오직 어드민, 프로젝트 슈퍼바이저, 프로젝트 매니저, CG 슈퍼바이저만
-		// 이 정보를 수정할 수 있도록 하기.
-		_ = u
-	}
-	r.ParseForm()
-	show := r.Form.Get("show")
-	if show == "" {
-		http.Error(w, "need 'show'", http.StatusBadRequest)
-		return
-	}
-	exist, err := roi.ShowExist(DB, show)
-	if err != nil {
-		log.Print(err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if !exist {
-		http.Error(w, fmt.Sprintf("show '%s' not exist", show), http.StatusBadRequest)
-		return
-	}
-	shot := r.Form.Get("shot")
-	if shot == "" {
-		http.Error(w, "need 'shot'", http.StatusBadRequest)
-		return
-	}
-	task := r.Form.Get("task")
-	if task == "" {
-		http.Error(w, "need 'task'", http.StatusBadRequest)
-		return
-	}
-	version := r.Form.Get("version")
-	if version == "" {
-		http.Error(w, "need 'version'", http.StatusBadRequest)
-		return
-	}
+	show := r.FormValue("show")
+	shot := r.FormValue("shot")
+	task := r.FormValue("task")
 	taskID := fmt.Sprintf("%s.%s.%s", show, shot, task)
 	t, err := roi.GetTask(DB, show, shot, task)
 	if err != nil {
-		log.Printf("could not get task '%s': %v", taskID, err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		handleError(w, httpError{msg: err.Error(), code: http.StatusInternalServerError})
 		return
 	}
 	if t == nil {
-		http.Error(w, fmt.Sprintf("task '%s' not exist", taskID), http.StatusBadRequest)
+		handleError(w, fmt.Errorf("task not found: %s", taskID))
 		return
 	}
-	versionID := fmt.Sprintf("%s.%s.%s.v%v03d", show, shot, task, version)
+	version := r.FormValue("version")
+	versionID := fmt.Sprintf("%s.%s.%s.%s", show, shot, task, version)
 	if r.Method == "POST" {
-		err = r.ParseMultipartForm(1 << 20)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
 		exist, err := roi.VersionExist(DB, show, shot, task, version)
 		if err != nil {
-			log.Printf("could not check version '%s' exist: %v", versionID, err)
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			handleError(w, httpError{msg: fmt.Sprintf("could not check version exist: %s: %v", versionID, err), code: http.StatusInternalServerError})
 			return
 		}
 		if !exist {
-			http.Error(w, "version '%s' not exist", http.StatusBadRequest)
+			handleError(w, fmt.Errorf("version not found: %s", versionID))
 			return
 		}
-		timeForms, err := parseTimeForms(r.Form,
-			"created",
-		)
+		timeForms, err := parseTimeForms(r.Form, "created")
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			handleError(w, err)
 			return
 		}
-		src, mov, err := r.FormFile("mov")
+		mov := fmt.Sprintf("data/show/%s/%s/%s/%s/1.mov", show, shot, task, version)
+		err = saveFormFile(r, "mov", mov)
 		if err != nil {
-			if err != http.ErrMissingFile {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		} else {
-			defer src.Close()
-			if mov.Size > (32 << 20) {
-				http.Error(w, fmt.Sprintf("mov: file size too big (got %dMB, maximum 32MB)", mov.Size>>20), http.StatusBadRequest)
-				return
-			}
-			data, err := ioutil.ReadAll(src)
-			if err != nil {
-				http.Error(w, "could not get mov file data", http.StatusBadRequest)
-				return
-			}
-			err = os.MkdirAll(fmt.Sprintf("data/show/%s/%s/%s/%s", show, shot, task, version), 0755)
-			if err != nil {
-				log.Printf("could not create mov directory: %v", err)
-				http.Error(w, "internal error", http.StatusInternalServerError)
-				return
-			}
-			dst := fmt.Sprintf("data/show/%s/%s/%s/%s/1.mov", show, shot, task, version)
-			err = ioutil.WriteFile(dst, data, 0755)
-			if err != nil {
-				log.Printf("could not save mov file data: %v", err)
-				http.Error(w, "internal error", http.StatusInternalServerError)
-				return
-			}
+			handleError(w, err)
+			return
 		}
 		u := roi.UpdateVersionParam{
-			OutputFiles: fields(r.Form.Get("output_files")),
-			Images:      fields(r.Form.Get("images")),
-			WorkFile:    r.Form.Get("work_file"),
+			OutputFiles: fields(r.FormValue("output_files")),
+			Images:      fields(r.FormValue("images")),
+			WorkFile:    r.FormValue("work_file"),
 			Created:     timeForms["created"],
 		}
 		roi.UpdateVersion(DB, show, shot, task, version, u)
@@ -295,12 +154,11 @@ func updateVersionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	v, err := roi.GetVersion(DB, show, shot, task, version)
 	if err != nil {
-		log.Printf("could not get version '%s': %v", versionID, err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		handleError(w, httpError{msg: fmt.Sprintf("could not get version: %s: %v", versionID, err), code: http.StatusInternalServerError})
 		return
 	}
 	if v == nil {
-		http.Error(w, fmt.Sprintf("version '%s' not exist", versionID), http.StatusBadRequest)
+		handleError(w, fmt.Errorf("version not exist: %s", versionID))
 		return
 	}
 	recipe := struct {
@@ -309,7 +167,7 @@ func updateVersionHandler(w http.ResponseWriter, r *http.Request) {
 		Version      *roi.Version
 	}{
 		PageType:     "update",
-		LoggedInUser: session["userid"],
+		LoggedInUser: u.ID,
 		Version:      v,
 	}
 	err = executeTemplate(w, "update-version.html", recipe)


### PR DESCRIPTION
기존의 경우 http 요청을 처리할 때 재사용되는 코드들을 따로 함수로 빼고 싶었지만, go의 http 에러 처리의 특수성 때문에 그러기 어려웠습니다.
그래서 httpError 형을 만들어 에러 문자열 뿐만 아니라 http 상태도 함께 담아 반환할 수 있게 하였습니다.

알림: 이 PR에는 이를 이용한 version_handler.go의 구현도 함께 담겨있습니다. 원래는 따로 구현하는게 원칙이지만 추후 수정에 대한 참고로 사용하려 합니다.