### PR TITLE
Get{...}이 해당 항목을 찾지 못했을 때 NotFound 에러를 반환함

### DIFF
--- a/cmd/roi/api.go
+++ b/cmd/roi/api.go
@@ -147,8 +147,11 @@ func addShotApiHandler(w http.ResponseWriter, r *http.Request) {
 	if len(tasks) == 0 {
 		p, err := roi.GetShow(DB, show)
 		if err != nil {
-			log.Printf("could not get show: %v", err)
-			apiInternalServerError(w)
+			if errors.As(err, &roi.NotFound{}) {
+				handleError(w, BadRequest(err))
+				return
+			}
+			handleError(w, Internal(err))
 			return
 		}
 		tasks = p.DefaultTasks

--- a/cmd/roi/error.go
+++ b/cmd/roi/error.go
@@ -24,3 +24,11 @@ func handleError(w http.ResponseWriter, err error) {
 	log.Print(err)
 	http.Error(w, "internal error", http.StatusInternalServerError)
 }
+
+func BadRequest(err error) httpError {
+	return httpError{msg: err.Error(), code: http.StatusBadRequest}
+}
+
+func Internal(err error) httpError {
+	return httpError{msg: err.Error(), code: http.StatusInternalServerError}
+}

--- a/cmd/roi/handler.go
+++ b/cmd/roi/handler.go
@@ -31,14 +31,7 @@ func sessionUser(r *http.Request) (*roi.User, error) {
 	if user == "" {
 		return nil, nil
 	}
-	u, err := roi.GetUser(DB, user)
-	if err != nil {
-		return nil, httpError{msg: "could not get user information", code: http.StatusInternalServerError}
-	}
-	if u == nil {
-		return nil, httpError{msg: fmt.Sprintf("user not exist: %s", user), code: http.StatusBadRequest}
-	}
-	return u, nil
+	return roi.GetUser(DB, user)
 }
 
 func saveFormFile(r *http.Request, field string, dst string) error {

--- a/cmd/roi/shot_handler.go
+++ b/cmd/roi/shot_handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -47,8 +48,11 @@ func addShotHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	sw, err := roi.GetShow(DB, show)
 	if err != nil {
-		log.Printf("could not get show '%s': %v", show, err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		if errors.As(err, &roi.NotFound{}) {
+			handleError(w, BadRequest(err))
+			return
+		}
+		handleError(w, Internal(err))
 		return
 	}
 	if sw == nil {
@@ -213,8 +217,11 @@ func updateShotHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	s, err := roi.GetShot(DB, show, shot)
 	if err != nil {
-		log.Print(err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		if errors.As(err, &roi.NotFound{}) {
+			handleError(w, BadRequest(err))
+			return
+		}
+		handleError(w, Internal(err))
 		return
 	}
 	if s == nil {

--- a/cmd/roi/site_handler.go
+++ b/cmd/roi/site_handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"net/http"
 
@@ -39,8 +40,11 @@ func siteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	s, err := roi.GetSite(DB)
 	if err != nil {
-		log.Printf("could not get site: %v", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		if errors.As(err, &roi.NotFound{}) {
+			handleError(w, BadRequest(err))
+			return
+		}
+		handleError(w, Internal(err))
 		return
 	}
 	recipe := struct {

--- a/error.go
+++ b/error.go
@@ -1,0 +1,10 @@
+package roi
+
+type NotFound struct {
+	kind string
+	id   string
+}
+
+func (e NotFound) Error() string {
+	return e.kind + " not found: " + e.id
+}

--- a/shot.go
+++ b/shot.go
@@ -275,8 +275,8 @@ func shotFromRows(rows *sql.Rows) (*Shot, error) {
 	return s, nil
 }
 
-// GetShot은 db의 특정 프로젝트에서 샷 이름으로 해당 샷을 찾는다.
-// 만일 그 이름의 샷이 없다면 nil이 반환된다.
+// GetShot은 db에서 하나의 샷을 찾는다.
+// 해당 샷이 존재하지 않는다면 nil과 NotFound 에러를 반환한다.
 func GetShot(db *sql.DB, prj string, shot string) (*Shot, error) {
 	keystr := strings.Join(ShotTableKeys, ", ")
 	stmt := fmt.Sprintf("SELECT %s FROM shots WHERE show=$1 AND shot=$2 LIMIT 1", keystr)
@@ -286,7 +286,8 @@ func GetShot(db *sql.DB, prj string, shot string) (*Shot, error) {
 	}
 	ok := rows.Next()
 	if !ok {
-		return nil, nil
+		id := prj + "/" + shot
+		return nil, NotFound{"shot", id}
 	}
 	return shotFromRows(rows)
 }

--- a/show.go
+++ b/show.go
@@ -311,8 +311,8 @@ func showFromRows(rows *sql.Rows) (*Show, error) {
 	return p, nil
 }
 
-// GetShow는 db에서 특정 쇼 정보를 부른다.
-// 해당 쇼가 없다면 nil이 반환된다.
+// GetShow는 db에서 하나의 쇼를 부른다.
+// 해당 쇼가 없다면 nil과 NotFound 에러를 반환한다.
 func GetShow(db *sql.DB, prj string) (*Show, error) {
 	keystr := strings.Join(ShowTableKeys, ", ")
 	stmt := fmt.Sprintf("SELECT %s FROM shows WHERE show=$1", keystr)
@@ -321,7 +321,7 @@ func GetShow(db *sql.DB, prj string) (*Show, error) {
 		return nil, err
 	}
 	if !rows.Next() {
-		return nil, nil
+		return nil, NotFound{"show", prj}
 	}
 	p, err := showFromRows(rows)
 	if err != nil {

--- a/site.go
+++ b/site.go
@@ -2,7 +2,6 @@ package roi
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -132,7 +131,7 @@ func siteFromRows(rows *sql.Rows) (*Site, error) {
 }
 
 // GetSite는 db에서 사이트 정보를 가지고 온다.
-// 사이트 정보는 항상 존재해야 한다.
+// 사이트 정보가 존재하지 않으면 nil과 NotFound 에러를 반환한다.
 func GetSite(db *sql.DB) (*Site, error) {
 	keystr := strings.Join(SitesTableKeys, ", ")
 	stmt := fmt.Sprintf("SELECT %s FROM sites LIMIT 1", keystr)
@@ -142,7 +141,7 @@ func GetSite(db *sql.DB) (*Site, error) {
 	}
 	ok := rows.Next()
 	if !ok {
-		return nil, errors.New("site should exist")
+		return nil, NotFound{"site", "(only one yet)"}
 	}
 	return siteFromRows(rows)
 }

--- a/task.go
+++ b/task.go
@@ -226,8 +226,8 @@ func taskFromRows(rows *sql.Rows) (*Task, error) {
 	return t, nil
 }
 
-// GetTask는 db의 특정 프로젝트에서 해당 태스크를 찾는다.
-// 만일 그 이름의 태스크가 없다면 nil이 반환된다.
+// GetTask는 db에서 하나의 태스크를 찾는다.
+// 해당 태스크가 없다면 nil과 NotFound 에러를 반환한다.
 func GetTask(db *sql.DB, prj, shot, task string) (*Task, error) {
 	keystr := strings.Join(TaskTableKeys, ", ")
 	stmt := fmt.Sprintf("SELECT %s FROM tasks WHERE show=$1 AND shot=$2 AND task=$3 LIMIT 1", keystr)
@@ -237,7 +237,8 @@ func GetTask(db *sql.DB, prj, shot, task string) (*Task, error) {
 	}
 	ok := rows.Next()
 	if !ok {
-		return nil, nil
+		id := prj + "/" + shot + "/" + task
+		return nil, NotFound{"task", id}
 	}
 	return taskFromRows(rows)
 }

--- a/user.go
+++ b/user.go
@@ -139,7 +139,7 @@ func Users(db *sql.DB) ([]*User, error) {
 }
 
 // GetUser는 db에서 사용자를 검색한다.
-// 해당 유저를 찾지 못하면 nil이 반환된다.
+// 해당 유저를 찾지 못하면 nil과 NotFound 에러를 반환한다.
 func GetUser(db *sql.DB, id string) (*User, error) {
 	keystr := strings.Join(UserTableKeys, ", ")
 	stmt := fmt.Sprintf("SELECT %s FROM users WHERE id='%s'", keystr, id)
@@ -149,7 +149,7 @@ func GetUser(db *sql.DB, id string) (*User, error) {
 	}
 	ok := rows.Next()
 	if !ok {
-		return nil, nil
+		return nil, NotFound{"user", id}
 	}
 	u := &User{}
 	if err := rows.Scan(&u.ID, &u.KorName, &u.Name, &u.Team, &u.Role, &u.Email, &u.PhoneNumber, &u.EntryDate); err != nil {

--- a/version.go
+++ b/version.go
@@ -198,8 +198,8 @@ func versionFromRows(rows *sql.Rows) (*Version, error) {
 	return v, nil
 }
 
-// GetVersion은 db의 특정 태스크의 해당 아웃풋을 찾는다.
-// 만일 그 버전의 아웃풋이 없다면 nil이 반환된다.
+// GetVersion은 db에서 하나의 버전을 찾는다.
+// 해당 버전이 없다면 nil과 NotFound 에러를 반환한다.
 func GetVersion(db *sql.DB, prj, shot, task string, version string) (*Version, error) {
 	keystr := strings.Join(VersionTableKeys, ", ")
 	stmt := fmt.Sprintf("SELECT %s FROM versions WHERE show=$1 AND shot=$2 AND task=$3 AND version=$4 LIMIT 1", keystr)
@@ -209,7 +209,8 @@ func GetVersion(db *sql.DB, prj, shot, task string, version string) (*Version, e
 	}
 	ok := rows.Next()
 	if !ok {
-		return nil, nil
+		id := prj + "/" + shot + "/" + task + "/" + version
+		return nil, NotFound{"version", id}
 	}
 	return versionFromRows(rows)
 }


### PR DESCRIPTION
이 때까지는 해당 항목이 없을 때 에러를 내지 않았는데,
해당 항목도 nil로 들어와서 깜빡 잊고 처리를 하지 않았을때
nil derefernce 에러가 날 확률이 있었고, 또한 그 사례도
발견하였다. 그래서 Get이 항목을 찾지 못하면 NotFound 에러를
내도록 변경하였다.

또한 에러 처리를 전반적으로 통일하였다.