### PR TITLE
에러 핸들링을 다시 정의함

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -20,7 +20,11 @@ func initTestDB() (*sql.DB, error) {
 
 // testDB는 로이의 테스트 DB 핸들러를 반환한다.
 func testDB() (*sql.DB, error) {
-	return sql.Open("postgres", "postgresql://root@localhost:54545/roi?sslmode=disable")
+	db, err := sql.Open("postgres", "postgresql://root@localhost:54545/roi?sslmode=disable")
+	if err != nil {
+		return nil, Internal{err}
+	}
+	return db, nil
 }
 
 func TestMain(m *testing.M) {

--- a/all_test.go
+++ b/all_test.go
@@ -22,7 +22,7 @@ func initTestDB() (*sql.DB, error) {
 func testDB() (*sql.DB, error) {
 	db, err := sql.Open("postgres", "postgresql://root@localhost:54545/roi?sslmode=disable")
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	return db, nil
 }

--- a/cmd/roi/api.go
+++ b/cmd/roi/api.go
@@ -147,11 +147,7 @@ func addShotApiHandler(w http.ResponseWriter, r *http.Request) {
 	if len(tasks) == 0 {
 		p, err := roi.GetShow(DB, show)
 		if err != nil {
-			if errors.As(err, &roi.NotFound{}) {
-				handleError(w, BadRequest(err))
-				return
-			}
-			handleError(w, Internal(err))
+			handleError(w, err)
 			return
 		}
 		tasks = p.DefaultTasks

--- a/cmd/roi/error.go
+++ b/cmd/roi/error.go
@@ -12,10 +12,11 @@ func handleError(w http.ResponseWriter, err error) {
 	var e roi.Error
 	if errors.As(err, &e) {
 		if e.Log() != "" {
-			log.Print(err)
+			log.Print(e.Log())
 		}
 		http.Error(w, e.Error(), e.Code())
+		return
 	}
 	log.Print(err)
-	http.Error(w, "unspecified internal error", http.StatusInternalServerError)
+	http.Error(w, "internal error", http.StatusInternalServerError)
 }

--- a/cmd/roi/error.go
+++ b/cmd/roi/error.go
@@ -1,34 +1,21 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"net/http"
+
+	"github.com/studio2l/roi"
 )
 
-type httpError struct {
-	msg  string
-	code int
-}
-
-func (e httpError) Error() string {
-	return e.msg
-}
-
 func handleError(w http.ResponseWriter, err error) {
-	if e, ok := err.(httpError); ok {
-		if e.code != http.StatusInternalServerError {
-			http.Error(w, e.msg, e.code)
-			return
+	var e roi.Error
+	if errors.As(err, &e) {
+		if e.Log() != "" {
+			log.Print(err)
 		}
+		http.Error(w, e.Error(), e.Code())
 	}
 	log.Print(err)
-	http.Error(w, "internal error", http.StatusInternalServerError)
-}
-
-func BadRequest(err error) httpError {
-	return httpError{msg: err.Error(), code: http.StatusBadRequest}
-}
-
-func Internal(err error) httpError {
-	return httpError{msg: err.Error(), code: http.StatusInternalServerError}
+	http.Error(w, "unspecified internal error", http.StatusInternalServerError)
 }

--- a/cmd/roi/handler.go
+++ b/cmd/roi/handler.go
@@ -14,7 +14,7 @@ import (
 func mustFields(r *http.Request, keys ...string) error {
 	for _, k := range keys {
 		if r.FormValue(k) == "" {
-			return roi.BadRequest{fmt.Sprintf("form field not found: %s", k)}
+			return roi.BadRequest{Msg: fmt.Sprintf("form field not found: %s", k)}
 		}
 	}
 	return nil
@@ -26,7 +26,7 @@ func mustFields(r *http.Request, keys ...string) error {
 func sessionUser(r *http.Request) (*roi.User, error) {
 	session, err := getSession(r)
 	if err != nil {
-		return nil, roi.Internal{errors.New("could not get session")}
+		return nil, roi.Internal{Err: errors.New("could not get session")}
 	}
 	user := session["userid"]
 	if user == "" {
@@ -46,19 +46,19 @@ func saveFormFile(r *http.Request, field string, dst string) error {
 	}
 	defer f.Close()
 	if fi.Size > (32 << 20) {
-		return roi.BadRequest{fmt.Sprintf("mov: file size too big (got %dMB, maximum 32MB)", fi.Size>>20)}
+		return roi.BadRequest{Msg: fmt.Sprintf("mov: file size too big (got %dMB, maximum 32MB)", fi.Size>>20)}
 	}
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		return roi.Internal{fmt.Errorf("could not read file data: %w", err)}
+		return roi.Internal{Err: fmt.Errorf("could not read file data: %w", err)}
 	}
 	err = os.MkdirAll(filepath.Dir(dst), 0755)
 	if err != nil {
-		return roi.Internal{fmt.Errorf("could not create directory: %w", err)}
+		return roi.Internal{Err: fmt.Errorf("could not create directory: %w", err)}
 	}
 	err = ioutil.WriteFile(dst, data, 0755)
 	if err != nil {
-		return roi.Internal{fmt.Errorf("could not save file: %w", err)}
+		return roi.Internal{Err: fmt.Errorf("could not save file: %w", err)}
 	}
 	return nil
 }

--- a/cmd/roi/handler.go
+++ b/cmd/roi/handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -14,7 +13,7 @@ import (
 func mustFields(r *http.Request, keys ...string) error {
 	for _, k := range keys {
 		if r.FormValue(k) == "" {
-			return roi.BadRequest{Msg: fmt.Sprintf("form field not found: %s", k)}
+			return roi.BadRequest(fmt.Sprintf("form field not found: %s", k))
 		}
 	}
 	return nil
@@ -26,7 +25,7 @@ func mustFields(r *http.Request, keys ...string) error {
 func sessionUser(r *http.Request) (*roi.User, error) {
 	session, err := getSession(r)
 	if err != nil {
-		return nil, roi.Internal{Err: errors.New("could not get session")}
+		return nil, roi.Internal(fmt.Errorf("could not get session: %w", err))
 	}
 	user := session["userid"]
 	if user == "" {
@@ -46,19 +45,19 @@ func saveFormFile(r *http.Request, field string, dst string) error {
 	}
 	defer f.Close()
 	if fi.Size > (32 << 20) {
-		return roi.BadRequest{Msg: fmt.Sprintf("mov: file size too big (got %dMB, maximum 32MB)", fi.Size>>20)}
+		return roi.BadRequest(fmt.Sprintf("mov: file size too big (got %dMB, maximum 32MB)", fi.Size>>20))
 	}
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		return roi.Internal{Err: fmt.Errorf("could not read file data: %w", err)}
+		return roi.Internal(fmt.Errorf("could not read file data: %w", err))
 	}
 	err = os.MkdirAll(filepath.Dir(dst), 0755)
 	if err != nil {
-		return roi.Internal{Err: fmt.Errorf("could not create directory: %w", err)}
+		return roi.Internal(fmt.Errorf("could not create directory: %w", err))
 	}
 	err = ioutil.WriteFile(dst, data, 0755)
 	if err != nil {
-		return roi.Internal{Err: fmt.Errorf("could not save file: %w", err)}
+		return roi.Internal(fmt.Errorf("could not save file: %w", err))
 	}
 	return nil
 }

--- a/cmd/roi/shot_handler.go
+++ b/cmd/roi/shot_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -48,11 +47,7 @@ func addShotHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	sw, err := roi.GetShow(DB, show)
 	if err != nil {
-		if errors.As(err, &roi.NotFound{}) {
-			handleError(w, BadRequest(err))
-			return
-		}
-		handleError(w, Internal(err))
+		handleError(w, err)
 		return
 	}
 	if sw == nil {
@@ -217,11 +212,7 @@ func updateShotHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	s, err := roi.GetShot(DB, show, shot)
 	if err != nil {
-		if errors.As(err, &roi.NotFound{}) {
-			handleError(w, BadRequest(err))
-			return
-		}
-		handleError(w, Internal(err))
+		handleError(w, err)
 		return
 	}
 	if s == nil {

--- a/cmd/roi/show_handler.go
+++ b/cmd/roi/show_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -47,11 +46,7 @@ func addShowHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	u, err := roi.GetUser(DB, session["userid"])
 	if err != nil {
-		if errors.As(err, &roi.NotFound{}) {
-			handleError(w, BadRequest(err))
-			return
-		}
-		handleError(w, Internal(err))
+		handleError(w, err)
 		return
 	}
 	if u.Role != "admin" {
@@ -112,11 +107,7 @@ func addShowHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	si, err := roi.GetSite(DB)
 	if err != nil {
-		if errors.As(err, &roi.NotFound{}) {
-			handleError(w, BadRequest(err))
-			return
-		}
-		handleError(w, Internal(err))
+		handleError(w, err)
 		return
 	}
 	s := &roi.Show{

--- a/cmd/roi/site_handler.go
+++ b/cmd/roi/site_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"log"
 	"net/http"
 
@@ -40,11 +39,7 @@ func siteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	s, err := roi.GetSite(DB)
 	if err != nil {
-		if errors.As(err, &roi.NotFound{}) {
-			handleError(w, BadRequest(err))
-			return
-		}
-		handleError(w, Internal(err))
+		handleError(w, err)
 		return
 	}
 	recipe := struct {

--- a/cmd/roi/task_handler.go
+++ b/cmd/roi/task_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -79,11 +78,7 @@ func updateTaskHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	t, err := roi.GetTask(DB, show, shot, task)
 	if err != nil {
-		if errors.As(err, &roi.NotFound{}) {
-			handleError(w, BadRequest(err))
-			return
-		}
-		handleError(w, Internal(err))
+		handleError(w, err)
 		return
 	}
 	vers, err := roi.TaskVersions(DB, show, shot, task)

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -44,11 +43,7 @@ func addVersionHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		_, err = roi.GetTask(DB, show, shot, task)
 		if err != nil {
-			if errors.As(err, &roi.NotFound{}) {
-				handleError(w, BadRequest(err))
-				return
-			}
-			handleError(w, Internal(err))
+			handleError(w, err)
 			return
 		}
 		mov := fmt.Sprintf("data/show/%s/%s/%s/%s/1.mov", show, shot, task, version)
@@ -68,7 +63,7 @@ func addVersionHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		err = roi.AddVersion(DB, show, shot, task, v)
 		if err != nil {
-			handleError(w, httpError{msg: fmt.Sprintf("could not add version to task '%s': %v", taskID, err), code: http.StatusInternalServerError})
+			handleError(w, fmt.Errorf("could not add version to task '%s': %w", taskID, err))
 			return
 		}
 		http.Redirect(w, r, fmt.Sprintf("/update-version?show=%s&shot=%s&task=%s&version=%s", show, shot, task, version), http.StatusSeeOther)
@@ -116,11 +111,7 @@ func updateVersionHandler(w http.ResponseWriter, r *http.Request) {
 	task := r.FormValue("task")
 	_, err = roi.GetTask(DB, show, shot, task)
 	if err != nil {
-		if errors.As(err, &roi.NotFound{}) {
-			handleError(w, BadRequest(err))
-			return
-		}
-		handleError(w, Internal(err))
+		handleError(w, err)
 		return
 	}
 	version := r.FormValue("version")
@@ -128,7 +119,7 @@ func updateVersionHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "POST" {
 		exist, err := roi.VersionExist(DB, show, shot, task, version)
 		if err != nil {
-			handleError(w, httpError{msg: fmt.Sprintf("could not check version exist: %s: %v", versionID, err), code: http.StatusInternalServerError})
+			handleError(w, err)
 			return
 		}
 		if !exist {
@@ -158,11 +149,7 @@ func updateVersionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	v, err := roi.GetVersion(DB, show, shot, task, version)
 	if err != nil {
-		if errors.As(err, &roi.NotFound{}) {
-			handleError(w, BadRequest(err))
-			return
-		}
-		handleError(w, Internal(err))
+		handleError(w, err)
 		return
 	}
 	recipe := struct {

--- a/db.go
+++ b/db.go
@@ -17,45 +17,45 @@ func InitDB() (*sql.DB, error) {
 func initDB(addr string) (*sql.DB, error) {
 	db, err := sql.Open("postgres", addr)
 	if err != nil {
-		return nil, Internal{fmt.Errorf("could not open database with root user: %w", err)}
+		return nil, Internal(fmt.Errorf("could not open database with root user: %w", err))
 	}
 	tx, err := db.Begin()
 	if err != nil {
-		return nil, Internal{fmt.Errorf("could not begin a transaction: %w", err)}
+		return nil, Internal(fmt.Errorf("could not begin a transaction: %w", err))
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 
 	// 밑의 구문들은 다 여러번 실행해도 안전한 구문들이다.
 	if _, err := tx.Exec("CREATE USER IF NOT EXISTS roiuser"); err != nil {
-		return nil, Internal{fmt.Errorf("could not create user 'roiuser': %w", err)}
+		return nil, Internal(fmt.Errorf("could not create user 'roiuser': %w", err))
 	}
 	if _, err := tx.Exec("CREATE DATABASE IF NOT EXISTS roi"); err != nil {
-		return nil, Internal{fmt.Errorf("could not create db 'roi': %w", err)}
+		return nil, Internal(fmt.Errorf("could not create db 'roi': %w", err))
 	}
 	if _, err := tx.Exec("GRANT ALL ON DATABASE roi TO roiuser"); err != nil {
-		return nil, Internal{fmt.Errorf("could not grant 'roi' to 'roiuser': %w", err)}
+		return nil, Internal(fmt.Errorf("could not grant 'roi' to 'roiuser': %w", err))
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsSitesStmt); err != nil {
-		return nil, Internal{fmt.Errorf("could not create 'sites' table: %w", err)}
+		return nil, Internal(fmt.Errorf("could not create 'sites' table: %w", err))
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsShowsStmt); err != nil {
-		return nil, Internal{fmt.Errorf("could not create 'projects' table: %w", err)}
+		return nil, Internal(fmt.Errorf("could not create 'projects' table: %w", err))
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsShotsStmt); err != nil {
-		return nil, Internal{fmt.Errorf("could not create 'shots' table: %w", err)}
+		return nil, Internal(fmt.Errorf("could not create 'shots' table: %w", err))
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsTasksStmt); err != nil {
-		return nil, Internal{fmt.Errorf("could not create 'tasks' table: %w", err)}
+		return nil, Internal(fmt.Errorf("could not create 'tasks' table: %w", err))
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsVersionsStmt); err != nil {
-		return nil, Internal{fmt.Errorf("could not create 'versions' table: %w", err)}
+		return nil, Internal(fmt.Errorf("could not create 'versions' table: %w", err))
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsUsersStmt); err != nil {
-		return nil, Internal{fmt.Errorf("could not create 'users' table: %w", err)}
+		return nil, Internal(fmt.Errorf("could not create 'users' table: %w", err))
 	}
 	err = tx.Commit()
 	if err != nil {
-		return nil, Internal{fmt.Errorf("could not commit transaction: %w", err)}
+		return nil, Internal(fmt.Errorf("could not commit transaction: %w", err))
 	}
 	return db, nil
 }
@@ -64,7 +64,7 @@ func initDB(addr string) (*sql.DB, error) {
 func DB() (*sql.DB, error) {
 	db, err := sql.Open("postgres", "postgresql://roiuser@localhost:26257/roi?sslmode=disable")
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	return db, nil
 }

--- a/db.go
+++ b/db.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	_ "image/jpeg"
-	"log"
 	"strconv"
 )
 
@@ -18,52 +17,56 @@ func InitDB() (*sql.DB, error) {
 func initDB(addr string) (*sql.DB, error) {
 	db, err := sql.Open("postgres", addr)
 	if err != nil {
-		return nil, fmt.Errorf("could not the database with root user: %v", err)
+		return nil, Internal{fmt.Errorf("could not open database with root user: %w", err)}
 	}
 	tx, err := db.Begin()
 	if err != nil {
-		return nil, fmt.Errorf("could not begin a transaction: %v", err)
+		return nil, Internal{fmt.Errorf("could not begin a transaction: %w", err)}
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 
 	// 밑의 구문들은 다 여러번 실행해도 안전한 구문들이다.
 	if _, err := tx.Exec("CREATE USER IF NOT EXISTS roiuser"); err != nil {
-		log.Fatal("could not create user 'roiuser': ", err)
+		return nil, Internal{fmt.Errorf("could not create user 'roiuser': %w", err)}
 	}
 	if _, err := tx.Exec("CREATE DATABASE IF NOT EXISTS roi"); err != nil {
-		log.Fatal("could not create db 'roi': ", err)
+		return nil, Internal{fmt.Errorf("could not create db 'roi': %w", err)}
 	}
 	if _, err := tx.Exec("GRANT ALL ON DATABASE roi TO roiuser"); err != nil {
-		log.Fatal("could not grant 'roi' to 'roiuser': ", err)
+		return nil, Internal{fmt.Errorf("could not grant 'roi' to 'roiuser': %w", err)}
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsSitesStmt); err != nil {
-		return nil, fmt.Errorf("could not create 'sites' table: %v", err)
+		return nil, Internal{fmt.Errorf("could not create 'sites' table: %w", err)}
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsShowsStmt); err != nil {
-		return nil, fmt.Errorf("could not create 'projects' table: %v", err)
+		return nil, Internal{fmt.Errorf("could not create 'projects' table: %w", err)}
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsShotsStmt); err != nil {
-		return nil, fmt.Errorf("could not create 'shots' table: %v", err)
+		return nil, Internal{fmt.Errorf("could not create 'shots' table: %w", err)}
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsTasksStmt); err != nil {
-		return nil, fmt.Errorf("could not create 'tasks' table: %v", err)
+		return nil, Internal{fmt.Errorf("could not create 'tasks' table: %w", err)}
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsVersionsStmt); err != nil {
-		return nil, fmt.Errorf("could not create 'versions' table: %v", err)
+		return nil, Internal{fmt.Errorf("could not create 'versions' table: %w", err)}
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsUsersStmt); err != nil {
-		return nil, fmt.Errorf("could not create 'users' table: %v", err)
+		return nil, Internal{fmt.Errorf("could not create 'users' table: %w", err)}
 	}
 	err = tx.Commit()
 	if err != nil {
-		return nil, fmt.Errorf("could not commit the transaction: %v", err)
+		return nil, Internal{fmt.Errorf("could not commit transaction: %w", err)}
 	}
 	return db, nil
 }
 
 // DB는 로이의 DB 핸들러를 반환한다. 이 함수는 이미 로이 DB와 DB 유저가 생성되어 있다고 가정한다.
 func DB() (*sql.DB, error) {
-	return sql.Open("postgres", "postgresql://roiuser@localhost:26257/roi?sslmode=disable")
+	db, err := sql.Open("postgres", "postgresql://roiuser@localhost:26257/roi?sslmode=disable")
+	if err != nil {
+		return nil, Internal{err}
+	}
+	return db, nil
 }
 
 // dbIndices는 받아들인 문자열 슬라이스와 같은 길이의

--- a/error.go
+++ b/error.go
@@ -38,7 +38,7 @@ type BadRequestError struct {
 	msg string
 }
 
-// BadRequest는 BadRequestError 에러를 반환한다.
+// BadRequest는 BadRequestError를 반환한다.
 func BadRequest(msg string) BadRequestError {
 	return BadRequestError{msg: msg}
 }
@@ -55,13 +55,13 @@ func (e BadRequestError) Log() string {
 	return ""
 }
 
-// InternalError은 문제가 서버 밖으로 전달되지 않아야 하는 때 반환되는 에러이다.
+// InternalError은 문제가 서버 밖으로 전달되지 않아야 함을 의미하는 에러이다.
 // InternalError은 errors.Wrapper 인터페이스를 만족한다.
 type InternalError struct {
 	err error
 }
 
-// Internal은 InternalError 에러를 반환한다.
+// Internal은 InternalError를 반환한다.
 func Internal(err error) InternalError {
 	return InternalError{err}
 }
@@ -82,12 +82,13 @@ func (e InternalError) Unwrap() error {
 	return e.err
 }
 
-// AuthError는 특정 사용자가 허락되지 않은 행동을 요청했을 때 반환되는 에러이다.
+// AuthError는 특정 사용자가 허락되지 않은 행동을 요청했음을 의미하는 에러이다.
 type AuthError struct {
 	user string
 	op   string
 }
 
+// Auth는 AuthError를 반환한다.
 func Auth(user, op string) AuthError {
 	return AuthError{user: user, op: op}
 }

--- a/error.go
+++ b/error.go
@@ -10,77 +10,96 @@ type Error interface {
 	Log() string
 }
 
-// NotFound는 로이에서 특정 항목을 검색했지만 해당 항목이 없을 때 반환되는 에러이다.
-type NotFound struct {
-	Kind string
-	ID   string
+// NotFoundError는 로이에서 특정 항목을 검색했지만 해당 항목이 없음을 의미하는 에러이다.
+type NotFoundError struct {
+	kind string
+	id   string
 }
 
-func (e NotFound) Error() string {
-	return e.Kind + " not found: " + e.ID
+// NotFound는 NotFoundError를 반환한다.
+func NotFound(kind, id string) NotFoundError {
+	return NotFoundError{kind: kind, id: id}
 }
 
-func (e NotFound) Code() int {
+func (e NotFoundError) Error() string {
+	return e.kind + " not found: " + e.id
+}
+
+func (e NotFoundError) Code() int {
 	return http.StatusNotFound
 }
 
-func (e NotFound) Log() string {
+func (e NotFoundError) Log() string {
 	return ""
 }
 
-// BadRequest는 로이의 함수를 호출했지만 그와 관련된 정보가 부족하거나 잘못되었을 때 반환되는 에러이다.
-type BadRequest struct {
-	Msg string
+// BadRequestError는 로이의 함수를 호출했지만 그와 관련된 정보가 잘못되었음을 의미하는 에러이다.
+type BadRequestError struct {
+	msg string
 }
 
-func (e BadRequest) Error() string {
-	return e.Msg
+// BadRequest는 BadRequestError 에러를 반환한다.
+func BadRequest(msg string) BadRequestError {
+	return BadRequestError{msg: msg}
 }
 
-func (e BadRequest) Code() int {
+func (e BadRequestError) Error() string {
+	return e.msg
+}
+
+func (e BadRequestError) Code() int {
 	return http.StatusBadRequest
 }
 
-func (e BadRequest) Log() string {
+func (e BadRequestError) Log() string {
 	return ""
 }
 
-// Internal은 문제가 서버 밖으로 전달되지 않아야 하는 때 반환되는 에러이다.
-// Internal은 errors.Wrapper 인터페이스를 만족한다.
-type Internal struct {
-	Err error
+// InternalError은 문제가 서버 밖으로 전달되지 않아야 하는 때 반환되는 에러이다.
+// InternalError은 errors.Wrapper 인터페이스를 만족한다.
+type InternalError struct {
+	err error
 }
 
-func (e Internal) Error() string {
+// Internal은 InternalError 에러를 반환한다.
+func Internal(err error) InternalError {
+	return InternalError{err}
+}
+
+func (e InternalError) Error() string {
 	return "internal error"
 }
 
-func (e Internal) Code() int {
+func (e InternalError) Code() int {
 	return http.StatusInternalServerError
 }
 
-func (e Internal) Log() string {
-	return e.Err.Error()
+func (e InternalError) Log() string {
+	return e.err.Error()
 }
 
-func (e Internal) Unwrap() error {
-	return e.Err
+func (e InternalError) Unwrap() error {
+	return e.err
 }
 
-// Auth는 특정 사용자가 허락되지 않은 행동을 요청했을 때 반환되는 에러이다.
-type Auth struct {
-	User string
-	Op   string
+// AuthError는 특정 사용자가 허락되지 않은 행동을 요청했을 때 반환되는 에러이다.
+type AuthError struct {
+	user string
+	op   string
 }
 
-func (e Auth) Error() string {
-	return e.User + " has no right to do " + e.Op
+func Auth(user, op string) AuthError {
+	return AuthError{user: user, op: op}
 }
 
-func (e Auth) Code() int {
+func (e AuthError) Error() string {
+	return e.user + " has no right to do " + e.op
+}
+
+func (e AuthError) Code() int {
 	return http.StatusUnauthorized
 }
 
-func (e Auth) Log() string {
-	return e.User + " tried to do " + e.Op
+func (e AuthError) Log() string {
+	return e.user + " tried to do " + e.op
 }

--- a/error.go
+++ b/error.go
@@ -1,10 +1,86 @@
 package roi
 
+import "net/http"
+
+// Error는 error 인터페이스를 만족하는 roi의 에러 타입이다.
+// roi의 모든 에러는 Error 형이어야 한다.
+type Error interface {
+	Error() string
+	Code() int
+	Log() string
+}
+
+// NotFound는 로이에서 특정 항목을 검색했지만 해당 항목이 없을 때 반환되는 에러이다.
 type NotFound struct {
-	kind string
-	id   string
+	Kind string
+	ID   string
 }
 
 func (e NotFound) Error() string {
-	return e.kind + " not found: " + e.id
+	return e.Kind + " not found: " + e.ID
+}
+
+func (e NotFound) Code() int {
+	return http.StatusNotFound
+}
+
+func (e NotFound) Log() string {
+	return ""
+}
+
+// BadRequest는 로이의 함수를 호출했지만 그와 관련된 정보가 부족하거나 잘못되었을 때 반환되는 에러이다.
+type BadRequest struct {
+	Msg string
+}
+
+func (e BadRequest) Error() string {
+	return e.Msg
+}
+
+func (e BadRequest) Code() int {
+	return http.StatusBadRequest
+}
+
+func (e BadRequest) Log() string {
+	return ""
+}
+
+// Internal은 문제가 서버 밖으로 전달되지 않아야 하는 때 반환되는 에러이다.
+// Internal은 errors.Wrapper 인터페이스를 만족한다.
+type Internal struct {
+	Err error
+}
+
+func (e Internal) Error() string {
+	return "internal error"
+}
+
+func (e Internal) Code() int {
+	return http.StatusInternalServerError
+}
+
+func (e Internal) Log() string {
+	return e.Err.Error()
+}
+
+func (e Internal) Unwrap() error {
+	return e.Err
+}
+
+// Auth는 특정 사용자가 허락되지 않은 행동을 요청했을 때 반환되는 에러이다.
+type Auth struct {
+	User string
+	Op   string
+}
+
+func (e Auth) Error() string {
+	return e.User + " has no right to do " + e.Op
+}
+
+func (e Auth) Code() int {
+	return http.StatusUnauthorized
+}
+
+func (e Auth) Log() string {
+	return e.User + " tried to do " + e.Op
 }

--- a/shot.go
+++ b/shot.go
@@ -2,7 +2,6 @@ package roi
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -227,10 +226,10 @@ var ShotTableIndices = dbIndices(ShotTableKeys)
 // AddShot은 db의 특정 프로젝트에 샷을 하나 추가한다.
 func AddShot(db *sql.DB, prj string, s *Shot) error {
 	if prj == "" {
-		return fmt.Errorf("show code not specified")
+		return BadRequest{"show code not specified"}
 	}
 	if s == nil {
-		return errors.New("nil Shot is invalid")
+		return BadRequest{"nil shot is invalid"}
 	}
 	if s.Tags == nil {
 		s.Tags = make([]string, 0)
@@ -239,13 +238,13 @@ func AddShot(db *sql.DB, prj string, s *Shot) error {
 		s.WorkingTasks = make([]string, 0)
 	}
 	if !isValidShotStatus(s.Status) {
-		return fmt.Errorf("invalid shot status: '%s'", s.Status)
+		return BadRequest{fmt.Sprintf("invalid shot status: '%s'", s.Status)}
 	}
 	keys := strings.Join(ShotTableKeys, ", ")
 	idxs := strings.Join(ShotTableIndices, ", ")
 	stmt := fmt.Sprintf("INSERT INTO shots (%s) VALUES (%s)", keys, idxs)
 	if _, err := db.Exec(stmt, s.dbValues()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
@@ -255,7 +254,7 @@ func ShotExist(db *sql.DB, prj, shot string) (bool, error) {
 	stmt := "SELECT shot FROM shots WHERE show=$1 AND shot=$2 LIMIT 1"
 	rows, err := db.Query(stmt, prj, shot)
 	if err != nil {
-		return false, err
+		return false, Internal{err}
 	}
 	return rows.Next(), nil
 }
@@ -270,7 +269,7 @@ func shotFromRows(rows *sql.Rows) (*Shot, error) {
 		&s.StartDate, &s.EndDate, &s.DueDate,
 	)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	return s, nil
 }
@@ -282,7 +281,7 @@ func GetShot(db *sql.DB, prj string, shot string) (*Shot, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM shots WHERE show=$1 AND shot=$2 LIMIT 1", keystr)
 	rows, err := db.Query(stmt, prj, shot)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	ok := rows.Next()
 	if !ok {
@@ -349,7 +348,7 @@ func SearchShots(db *sql.DB, prj, shot, tag, status, assignee, task_status strin
 	}
 	rows, err := db.Query(stmt, vals...)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	defer rows.Close()
 	// 태스크 검색을 해 JOIN이 되면 샷이 중복으로 추가될 수 있다.
@@ -360,7 +359,7 @@ func SearchShots(db *sql.DB, prj, shot, tag, status, assignee, task_status strin
 	for rows.Next() {
 		s, err := shotFromRows(rows)
 		if err != nil {
-			return nil, err
+			return nil, Internal{err}
 		}
 		ok := hasShot[s.Shot]
 		if ok {
@@ -433,19 +432,19 @@ func (u UpdateShotParam) values() []interface{} {
 // UpdateShot은 db에서 해당 샷을 수정한다.
 func UpdateShot(db *sql.DB, prj, shot string, upd UpdateShotParam) error {
 	if prj == "" {
-		return fmt.Errorf("show code not specified")
+		return BadRequest{"show code not specified"}
 	}
 	if shot == "" {
-		return errors.New("shot id empty")
+		return BadRequest{"shot id empty"}
 	}
 	if !isValidShotStatus(upd.Status) {
-		return fmt.Errorf("invalid shot status: '%s'", upd.Status)
+		return BadRequest{fmt.Sprintf("invalid shot status: '%s'", upd.Status)}
 	}
 	keystr := strings.Join(upd.keys(), ", ")
 	idxstr := strings.Join(upd.indices(), ", ")
 	stmt := fmt.Sprintf("UPDATE shots SET (%s) = (%s) WHERE show='%s' AND shot='%s'", keystr, idxstr, prj, shot)
 	if _, err := db.Exec(stmt, upd.values()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
@@ -456,17 +455,21 @@ func UpdateShot(db *sql.DB, prj, shot string, upd UpdateShotParam) error {
 func DeleteShot(db *sql.DB, prj, shot string) error {
 	tx, err := db.Begin()
 	if err != nil {
-		return fmt.Errorf("could not begin a transaction: %v", err)
+		return Internal{fmt.Errorf("could not begin a transaction: %w", err)}
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 	if _, err := tx.Exec("DELETE FROM shots WHERE show=$1 AND shot=$2", prj, shot); err != nil {
-		return fmt.Errorf("could not delete data from 'shots' table: %v", err)
+		return Internal{fmt.Errorf("could not delete data from 'shots' table: %w", err)}
 	}
 	if _, err := tx.Exec("DELETE FROM tasks WHERE show=$1 AND shot=$2", prj, shot); err != nil {
-		return fmt.Errorf("could not delete data from 'tasks' table: %v", err)
+		return Internal{fmt.Errorf("could not delete data from 'tasks' table: %w", err)}
 	}
 	if _, err := tx.Exec("DELETE FROM versions WHERE show=$1 AND shot=$2", prj, shot); err != nil {
-		return fmt.Errorf("could not delete data from 'versions' table: %v", err)
+		return Internal{fmt.Errorf("could not delete data from 'versions' table: %w", err)}
 	}
-	return tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return Internal{err}
+	}
+	return nil
 }

--- a/show.go
+++ b/show.go
@@ -198,7 +198,7 @@ func AddShow(db *sql.DB, p *Show) error {
 	idxstr := strings.Join(ShowTableIndices, ", ")
 	stmt := fmt.Sprintf("INSERT INTO shows (%s) VALUES (%s)", keystr, idxstr)
 	if _, err := db.Exec(stmt, p.dbValues()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
@@ -276,13 +276,13 @@ func (u UpdateShowParam) values() []interface{} {
 // UpdateShow는 db의 쇼 정보를 수정한다.
 func UpdateShow(db *sql.DB, prj string, upd UpdateShowParam) error {
 	if !IsValidShow(prj) {
-		return fmt.Errorf("Show id is invalid: %s", prj)
+		return BadRequest{fmt.Sprintf("Show id is invalid: %s", prj)}
 	}
 	keystr := strings.Join(upd.keys(), ", ")
 	idxstr := strings.Join(upd.indices(), ", ")
 	stmt := fmt.Sprintf("UPDATE shows SET (%s) = (%s) WHERE show='%s'", keystr, idxstr, prj)
 	if _, err := db.Exec(stmt, upd.values()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
@@ -291,7 +291,7 @@ func UpdateShow(db *sql.DB, prj string, upd UpdateShowParam) error {
 func ShowExist(db *sql.DB, prj string) (bool, error) {
 	rows, err := db.Query("SELECT show FROM shows WHERE show=$1 LIMIT 1", prj)
 	if err != nil {
-		return false, err
+		return false, Internal{err}
 	}
 	return rows.Next(), nil
 }
@@ -306,7 +306,7 @@ func showFromRows(rows *sql.Rows) (*Show, error) {
 		&p.ViewLUT, pq.Array(&p.DefaultTasks),
 	)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	return p, nil
 }
@@ -318,7 +318,7 @@ func GetShow(db *sql.DB, prj string) (*Show, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM shows WHERE show=$1", keystr)
 	rows, err := db.Query(stmt, prj)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	if !rows.Next() {
 		return nil, NotFound{"show", prj}
@@ -337,7 +337,7 @@ func AllShows(db *sql.DB) ([]*Show, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM shows", fields)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	prjs := make([]*Show, 0)
 	for rows.Next() {
@@ -347,8 +347,8 @@ func AllShows(db *sql.DB) ([]*Show, error) {
 		}
 		prjs = append(prjs, p)
 	}
-	if rows.Err() != nil {
-		return nil, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, Internal{err}
 	}
 	return prjs, nil
 }
@@ -359,20 +359,20 @@ func AllShows(db *sql.DB) ([]*Show, error) {
 func DeleteShow(db *sql.DB, prj string) error {
 	tx, err := db.Begin()
 	if err != nil {
-		return fmt.Errorf("could not begin a transaction: %v", err)
+		return Internal{fmt.Errorf("could not begin a transaction: %v", err)}
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 	if _, err := tx.Exec("DELETE FROM shows WHERE show=$1", prj); err != nil {
-		return fmt.Errorf("could not delete data from 'shows' table: %v", err)
+		return Internal{fmt.Errorf("could not delete data from 'shows' table: %v", err)}
 	}
 	if _, err := tx.Exec("DELETE FROM shots WHERE show=$1", prj); err != nil {
-		return fmt.Errorf("could not delete data from 'shots' table: %v", err)
+		return Internal{fmt.Errorf("could not delete data from 'shots' table: %v", err)}
 	}
 	if _, err := tx.Exec("DELETE FROM tasks WHERE show=$1", prj); err != nil {
-		return fmt.Errorf("could not delete data from 'tasks' table: %v", err)
+		return Internal{fmt.Errorf("could not delete data from 'tasks' table: %v", err)}
 	}
 	if _, err := tx.Exec("DELETE FROM versions WHERE show=$1", prj); err != nil {
-		return fmt.Errorf("could not delete data from 'versions' table: %v", err)
+		return Internal{fmt.Errorf("could not delete data from 'versions' table: %v", err)}
 	}
 	return tx.Commit()
 }

--- a/site.go
+++ b/site.go
@@ -94,7 +94,7 @@ func AddSite(db *sql.DB) error {
 	idxs := strings.Join(SitesTableIndices, ", ")
 	stmt := fmt.Sprintf("INSERT INTO sites (%s) VALUES (%s) ON CONFLICT DO NOTHING", keys, idxs)
 	if _, err := db.Exec(stmt, s.dbValues()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
@@ -106,7 +106,7 @@ func UpdateSite(db *sql.DB, s *Site) error {
 	idxs := strings.Join(SitesTableIndices, ", ")
 	stmt := fmt.Sprintf("UPDATE sites SET (%s) = (%s) WHERE site='only'", keys, idxs)
 	if _, err := db.Exec(stmt, s.dbValues()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
@@ -125,7 +125,7 @@ func siteFromRows(rows *sql.Rows) (*Site, error) {
 		pq.Array(&s.Leads),
 	)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	return s, nil
 }
@@ -137,7 +137,7 @@ func GetSite(db *sql.DB) (*Site, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM sites LIMIT 1", keystr)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	ok := rows.Next()
 	if !ok {

--- a/site.go
+++ b/site.go
@@ -94,7 +94,7 @@ func AddSite(db *sql.DB) error {
 	idxs := strings.Join(SitesTableIndices, ", ")
 	stmt := fmt.Sprintf("INSERT INTO sites (%s) VALUES (%s) ON CONFLICT DO NOTHING", keys, idxs)
 	if _, err := db.Exec(stmt, s.dbValues()...); err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }
@@ -106,7 +106,7 @@ func UpdateSite(db *sql.DB, s *Site) error {
 	idxs := strings.Join(SitesTableIndices, ", ")
 	stmt := fmt.Sprintf("UPDATE sites SET (%s) = (%s) WHERE site='only'", keys, idxs)
 	if _, err := db.Exec(stmt, s.dbValues()...); err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }
@@ -125,7 +125,7 @@ func siteFromRows(rows *sql.Rows) (*Site, error) {
 		pq.Array(&s.Leads),
 	)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	return s, nil
 }
@@ -137,11 +137,11 @@ func GetSite(db *sql.DB) (*Site, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM sites LIMIT 1", keystr)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	ok := rows.Next()
 	if !ok {
-		return nil, NotFound{"site", "(only one yet)"}
+		return nil, NotFound("site", "(only one yet)")
 	}
 	return siteFromRows(rows)
 }

--- a/task.go
+++ b/task.go
@@ -128,25 +128,25 @@ var TaskTableIndices = dbIndices(TaskTableKeys)
 // AddTask는 db의 특정 프로젝트, 특정 샷에 태스크를 추가한다.
 func AddTask(db *sql.DB, prj, shot string, t *Task) error {
 	if prj == "" {
-		return BadRequest{"show not specified"}
+		return BadRequest("show not specified")
 	}
 	if shot == "" {
-		return BadRequest{"shot not specified"}
+		return BadRequest("shot not specified")
 	}
 	if t == nil {
-		return BadRequest{"nil task"}
+		return BadRequest("nil task")
 	}
 	if t.Task == "" {
-		return BadRequest{"task not specified"}
+		return BadRequest("task not specified")
 	}
 	if !isValidTaskStatus(t.Status) {
-		return BadRequest{fmt.Sprintf("invalid task status: '%s'", t.Status)}
+		return BadRequest(fmt.Sprintf("invalid task status: '%s'", t.Status))
 	}
 	keystr := strings.Join(TaskTableKeys, ", ")
 	idxstr := strings.Join(TaskTableIndices, ", ")
 	stmt := fmt.Sprintf("INSERT INTO tasks (%s) VALUES (%s)", keystr, idxstr)
 	if _, err := db.Exec(stmt, t.dbValues()...); err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }
@@ -182,22 +182,22 @@ func (u UpdateTaskParam) values() []interface{} {
 // UpdateTask는 db의 특정 태스크를 업데이트 한다.
 func UpdateTask(db *sql.DB, prj, shot, task string, upd UpdateTaskParam) error {
 	if prj == "" {
-		return BadRequest{"show not specified"}
+		return BadRequest("show not specified")
 	}
 	if shot == "" {
-		return BadRequest{"shot not specified"}
+		return BadRequest("shot not specified")
 	}
 	if task == "" {
-		return BadRequest{"task name not specified"}
+		return BadRequest("task name not specified")
 	}
 	if !isValidTaskStatus(upd.Status) {
-		return BadRequest{fmt.Sprintf("invalid task status: '%s'", upd.Status)}
+		return BadRequest(fmt.Sprintf("invalid task status: '%s'", upd.Status))
 	}
 	keystr := strings.Join(upd.keys(), ", ")
 	idxstr := strings.Join(upd.indices(), ", ")
 	stmt := fmt.Sprintf("UPDATE tasks SET (%s) = (%s) WHERE show='%s' AND shot='%s' AND task='%s'", keystr, idxstr, prj, shot, task)
 	if _, err := db.Exec(stmt, upd.values()...); err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }
@@ -207,7 +207,7 @@ func TaskExist(db *sql.DB, prj, shot, task string) (bool, error) {
 	stmt := "SELECT task FROM tasks WHERE show=$1 AND shot=$2 AND task=$3 LIMIT 1"
 	rows, err := db.Query(stmt, prj, shot, task)
 	if err != nil {
-		return false, Internal{err}
+		return false, Internal(err)
 	}
 	return rows.Next(), nil
 }
@@ -221,7 +221,7 @@ func taskFromRows(rows *sql.Rows) (*Task, error) {
 		&t.StartDate, &t.EndDate, &t.DueDate,
 	)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	return t, nil
 }
@@ -233,12 +233,12 @@ func GetTask(db *sql.DB, prj, shot, task string) (*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks WHERE show=$1 AND shot=$2 AND task=$3 LIMIT 1", keystr)
 	rows, err := db.Query(stmt, prj, shot, task)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	ok := rows.Next()
 	if !ok {
 		id := prj + "/" + shot + "/" + task
-		return nil, NotFound{"task", id}
+		return nil, NotFound("task", id)
 	}
 	return taskFromRows(rows)
 }
@@ -249,7 +249,7 @@ func ShotTasks(db *sql.DB, prj, shot string) ([]*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks WHERE show=$1 AND shot=$2", keystr)
 	rows, err := db.Query(stmt, prj, shot)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	tasks := make([]*Task, 0)
 	for rows.Next() {
@@ -275,7 +275,7 @@ func UserTasks(db *sql.DB, user string) ([]*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks JOIN shots ON (tasks.show = shots.show AND tasks.shot = shots.shot)  WHERE tasks.assignee='%s' AND tasks.task = ANY(shots.working_tasks)", keystr, user)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	tasks := make([]*Task, 0)
 	for rows.Next() {
@@ -309,7 +309,7 @@ func DeleteTask(db *sql.DB, prj, shot, task string) error {
 	}
 	err = tx.Commit()
 	if err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }

--- a/task.go
+++ b/task.go
@@ -128,25 +128,25 @@ var TaskTableIndices = dbIndices(TaskTableKeys)
 // AddTask는 db의 특정 프로젝트, 특정 샷에 태스크를 추가한다.
 func AddTask(db *sql.DB, prj, shot string, t *Task) error {
 	if prj == "" {
-		return fmt.Errorf("show not specified")
+		return BadRequest{"show not specified"}
 	}
 	if shot == "" {
-		return fmt.Errorf("shot not specified")
+		return BadRequest{"shot not specified"}
 	}
 	if t == nil {
-		return fmt.Errorf("nil task")
+		return BadRequest{"nil task"}
 	}
 	if t.Task == "" {
-		return fmt.Errorf("task name not specified")
+		return BadRequest{"task not specified"}
 	}
 	if !isValidTaskStatus(t.Status) {
-		return fmt.Errorf("invalid task status: '%s'", t.Status)
+		return BadRequest{fmt.Sprintf("invalid task status: '%s'", t.Status)}
 	}
 	keystr := strings.Join(TaskTableKeys, ", ")
 	idxstr := strings.Join(TaskTableIndices, ", ")
 	stmt := fmt.Sprintf("INSERT INTO tasks (%s) VALUES (%s)", keystr, idxstr)
 	if _, err := db.Exec(stmt, t.dbValues()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
@@ -182,22 +182,22 @@ func (u UpdateTaskParam) values() []interface{} {
 // UpdateTask는 db의 특정 태스크를 업데이트 한다.
 func UpdateTask(db *sql.DB, prj, shot, task string, upd UpdateTaskParam) error {
 	if prj == "" {
-		return fmt.Errorf("show not specified")
+		return BadRequest{"show not specified"}
 	}
 	if shot == "" {
-		return fmt.Errorf("shot not specified")
+		return BadRequest{"shot not specified"}
 	}
 	if task == "" {
-		return fmt.Errorf("task name not specified")
+		return BadRequest{"task name not specified"}
 	}
 	if !isValidTaskStatus(upd.Status) {
-		return fmt.Errorf("invalid task status: '%s'", upd.Status)
+		return BadRequest{fmt.Sprintf("invalid task status: '%s'", upd.Status)}
 	}
 	keystr := strings.Join(upd.keys(), ", ")
 	idxstr := strings.Join(upd.indices(), ", ")
 	stmt := fmt.Sprintf("UPDATE tasks SET (%s) = (%s) WHERE show='%s' AND shot='%s' AND task='%s'", keystr, idxstr, prj, shot, task)
 	if _, err := db.Exec(stmt, upd.values()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
@@ -207,7 +207,7 @@ func TaskExist(db *sql.DB, prj, shot, task string) (bool, error) {
 	stmt := "SELECT task FROM tasks WHERE show=$1 AND shot=$2 AND task=$3 LIMIT 1"
 	rows, err := db.Query(stmt, prj, shot, task)
 	if err != nil {
-		return false, err
+		return false, Internal{err}
 	}
 	return rows.Next(), nil
 }
@@ -221,7 +221,7 @@ func taskFromRows(rows *sql.Rows) (*Task, error) {
 		&t.StartDate, &t.EndDate, &t.DueDate,
 	)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	return t, nil
 }
@@ -233,7 +233,7 @@ func GetTask(db *sql.DB, prj, shot, task string) (*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks WHERE show=$1 AND shot=$2 AND task=$3 LIMIT 1", keystr)
 	rows, err := db.Query(stmt, prj, shot, task)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	ok := rows.Next()
 	if !ok {
@@ -249,7 +249,7 @@ func ShotTasks(db *sql.DB, prj, shot string) ([]*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks WHERE show=$1 AND shot=$2", keystr)
 	rows, err := db.Query(stmt, prj, shot)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	tasks := make([]*Task, 0)
 	for rows.Next() {
@@ -275,7 +275,7 @@ func UserTasks(db *sql.DB, user string) ([]*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks JOIN shots ON (tasks.show = shots.show AND tasks.shot = shots.shot)  WHERE tasks.assignee='%s' AND tasks.task = ANY(shots.working_tasks)", keystr, user)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	tasks := make([]*Task, 0)
 	for rows.Next() {
@@ -292,6 +292,10 @@ func UserTasks(db *sql.DB, user string) ([]*Task, error) {
 // 해당 태스크가 없어도 에러를 내지 않기 때문에 검사를 원한다면 TaskExist를 사용해야 한다.
 // 만일 처리 중간에 에러가 나면 아무 데이터도 지우지 않고 에러를 반환한다.
 func DeleteTask(db *sql.DB, prj, shot, task string) error {
+	_, err := GetTask(db, prj, shot, task)
+	if err != nil {
+		return err
+	}
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("could not begin a transaction: %v", err)
@@ -303,5 +307,9 @@ func DeleteTask(db *sql.DB, prj, shot, task string) error {
 	if _, err := tx.Exec("DELETE FROM versions WHERE show=$1 AND shot=$2 AND task=$3", prj, shot, task); err != nil {
 		return fmt.Errorf("could not delete data from 'versions' table: %v", err)
 	}
-	return tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return Internal{err}
+	}
+	return nil
 }

--- a/user.go
+++ b/user.go
@@ -112,7 +112,7 @@ func UserExist(db *sql.DB, id string) (bool, error) {
 	stmt := fmt.Sprintf("SELECT id FROM users WHERE id='%s'", id)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return false, Internal{err}
+		return false, Internal(err)
 	}
 	return rows.Next(), rows.Err()
 }
@@ -122,18 +122,18 @@ func Users(db *sql.DB) ([]*User, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM users", keystr)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	us := make([]*User, 0)
 	for rows.Next() {
 		u := &User{}
 		if err := rows.Scan(&u.ID, &u.KorName, &u.Name, &u.Team, &u.Role, &u.Email, &u.PhoneNumber, &u.EntryDate); err != nil {
-			return nil, Internal{err}
+			return nil, Internal(err)
 		}
 		us = append(us, u)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, Internal{fmt.Errorf("could not scan user: %v", err)}
+		return nil, Internal(fmt.Errorf("could not scan user: %v", err))
 	}
 	return us, nil
 }
@@ -145,15 +145,15 @@ func GetUser(db *sql.DB, id string) (*User, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM users WHERE id='%s'", keystr, id)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	ok := rows.Next()
 	if !ok {
-		return nil, NotFound{"user", id}
+		return nil, NotFound("user", id)
 	}
 	u := &User{}
 	if err := rows.Scan(&u.ID, &u.KorName, &u.Name, &u.Team, &u.Role, &u.Email, &u.PhoneNumber, &u.EntryDate); err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	return u, nil
 }
@@ -164,17 +164,17 @@ func UserPasswordMatch(db *sql.DB, id, pw string) (bool, error) {
 	stmt := fmt.Sprintf("SELECT hashed_password FROM users WHERE id='%s'", id)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return false, Internal{err}
+		return false, Internal(err)
 	}
 	ok := rows.Next()
 	if !ok {
-		return false, NotFound{"user", id}
+		return false, NotFound("user", id)
 	}
 	var hashed_password string
 	rows.Scan(&hashed_password)
 	err = bcrypt.CompareHashAndPassword([]byte(hashed_password), []byte(pw))
 	if err != nil {
-		return false, Internal{err}
+		return false, Internal(err)
 	}
 	return true, nil
 }
@@ -228,7 +228,7 @@ func UpdateUser(db *sql.DB, id string, u UpdateUserParam) error {
 	idxstr := strings.Join(u.indices(), ", ")
 	stmt := fmt.Sprintf("UPDATE users SET (%s) = (%s) WHERE id='%s'", keystr, idxstr, id)
 	if _, err := db.Exec(stmt, u.values()...); err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }
@@ -237,12 +237,12 @@ func UpdateUser(db *sql.DB, id string, u UpdateUserParam) error {
 func UpdateUserPassword(db *sql.DB, id, pw string) error {
 	hashed, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost)
 	if err != nil {
-		return Internal{fmt.Errorf("could not generate hash from password: %v", err)}
+		return Internal(fmt.Errorf("could not generate hash from password: %v", err))
 	}
 	hashed_password := string(hashed)
 	stmt := fmt.Sprintf("UPDATE users SET hashed_password=$1 WHERE id='%s'", id)
 	if _, err := db.Exec(stmt, hashed_password); err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }
@@ -256,7 +256,7 @@ func DeleteUser(db *sql.DB, id string) error {
 	}
 	stmt := fmt.Sprintf("DELETE FROM users WHERE id='%s'", id)
 	if _, err := db.Exec(stmt); err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }

--- a/version.go
+++ b/version.go
@@ -77,10 +77,10 @@ func (v *Version) dbValues() []interface{} {
 // AddVersion은 db의 특정 프로젝트, 특정 샷에 태스크를 추가한다.
 func AddVersion(db *sql.DB, prj, shot, task string, v *Version) error {
 	if prj == "" {
-		return BadRequest{"show not specified"}
+		return BadRequest("show not specified")
 	}
 	if shot == "" {
-		return BadRequest{"shot not specified"}
+		return BadRequest("shot not specified")
 	}
 	if task == "" {
 		return fmt.Errorf("task not specified")
@@ -92,19 +92,19 @@ func AddVersion(db *sql.DB, prj, shot, task string, v *Version) error {
 	idxstr := strings.Join(VersionTableIndices, ", ")
 	tx, err := db.Begin()
 	if err != nil {
-		return Internal{fmt.Errorf("could not begin a transaction: %v", err)}
+		return Internal(fmt.Errorf("could not begin a transaction: %v", err))
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 	stmt := fmt.Sprintf("INSERT INTO versions (%s) VALUES (%s)", keystr, idxstr)
 	if _, err := tx.Exec(stmt, v.dbValues()...); err != nil {
-		return Internal{fmt.Errorf("could not insert versions: %v", err)}
+		return Internal(fmt.Errorf("could not insert versions: %v", err))
 	}
 	if _, err := tx.Exec("UPDATE tasks SET status=$1, last_version=$2 WHERE show=$3 AND shot=$4 AND task=$5", TaskInProgress, v.Version, prj, shot, task); err != nil {
-		return Internal{fmt.Errorf("could not update last version of task: %v", err)}
+		return Internal(fmt.Errorf("could not update last version of task: %v", err))
 	}
 	err = tx.Commit()
 	if err != nil {
-		return Internal{fmt.Errorf("could not commit the transaction: %v", err)}
+		return Internal(fmt.Errorf("could not commit the transaction: %v", err))
 	}
 	return nil
 }
@@ -152,22 +152,22 @@ func (u UpdateVersionParam) values() []interface{} {
 // UpdateVersion은 db의 특정 태스크를 업데이트 한다.
 func UpdateVersion(db *sql.DB, prj, shot, task string, version string, upd UpdateVersionParam) error {
 	if prj == "" {
-		return BadRequest{"show not specified"}
+		return BadRequest("show not specified")
 	}
 	if shot == "" {
-		return BadRequest{"shot not specified"}
+		return BadRequest("shot not specified")
 	}
 	if task == "" {
-		return BadRequest{"task not specified"}
+		return BadRequest("task not specified")
 	}
 	if version == "" {
-		return BadRequest{"version not specified"}
+		return BadRequest("version not specified")
 	}
 	keystr := strings.Join(upd.keys(), ", ")
 	idxstr := strings.Join(upd.indices(), ", ")
 	stmt := fmt.Sprintf("UPDATE versions SET (%s) = (%s) WHERE show='%s' AND shot='%s' AND task='%s' AND version='%s'", keystr, idxstr, prj, shot, task, version)
 	if _, err := db.Exec(stmt, upd.values()...); err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }
@@ -175,21 +175,21 @@ func UpdateVersion(db *sql.DB, prj, shot, task string, version string, upd Updat
 // VersionExist는 db에 해당 태스크가 존재하는지를 검사한다.
 func VersionExist(db *sql.DB, prj, shot, task string, version string) (bool, error) {
 	if prj == "" {
-		return false, BadRequest{"show not specified"}
+		return false, BadRequest("show not specified")
 	}
 	if shot == "" {
-		return false, BadRequest{"shot not specified"}
+		return false, BadRequest("shot not specified")
 	}
 	if task == "" {
-		return false, BadRequest{"task not specified"}
+		return false, BadRequest("task not specified")
 	}
 	if version == "" {
-		return false, BadRequest{"version not specified"}
+		return false, BadRequest("version not specified")
 	}
 	stmt := "SELECT version FROM versions WHERE show=$1 AND shot=$2 AND task=$3 AND version=$4 LIMIT 1"
 	rows, err := db.Query(stmt, prj, shot, task, version)
 	if err != nil {
-		return false, Internal{err}
+		return false, Internal(err)
 	}
 	return rows.Next(), nil
 }
@@ -202,7 +202,7 @@ func versionFromRows(rows *sql.Rows) (*Version, error) {
 		&v.Version, pq.Array(&v.OutputFiles), pq.Array(&v.Images), &v.Mov, &v.WorkFile, &v.Created,
 	)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	return v, nil
 }
@@ -214,12 +214,12 @@ func GetVersion(db *sql.DB, prj, shot, task string, version string) (*Version, e
 	stmt := fmt.Sprintf("SELECT %s FROM versions WHERE show=$1 AND shot=$2 AND task=$3 AND version=$4 LIMIT 1", keystr)
 	rows, err := db.Query(stmt, prj, shot, task, version)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	ok := rows.Next()
 	if !ok {
 		id := prj + "/" + shot + "/" + task + "/" + version
-		return nil, NotFound{"version", id}
+		return nil, NotFound("version", id)
 	}
 	return versionFromRows(rows)
 }
@@ -230,7 +230,7 @@ func TaskVersions(db *sql.DB, prj, shot, task string) ([]*Version, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM versions WHERE show=$1 AND shot=$2 AND task=$3", keystr)
 	rows, err := db.Query(stmt, prj, shot, task)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	versions := make([]*Version, 0)
 	for rows.Next() {
@@ -249,7 +249,7 @@ func ShotVersions(db *sql.DB, prj, shot string) ([]*Version, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM versions WHERE show=$1 AND shot=$2", keystr)
 	rows, err := db.Query(stmt, prj, shot)
 	if err != nil {
-		return nil, Internal{err}
+		return nil, Internal(err)
 	}
 	versions := make([]*Version, 0)
 	for rows.Next() {
@@ -268,15 +268,15 @@ func ShotVersions(db *sql.DB, prj, shot string) ([]*Version, error) {
 func DeleteVersion(db *sql.DB, prj, shot, task string, version string) error {
 	tx, err := db.Begin()
 	if err != nil {
-		return Internal{fmt.Errorf("could not begin a transaction: %w", err)}
+		return Internal(fmt.Errorf("could not begin a transaction: %w", err))
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 	if _, err := tx.Exec("DELETE FROM versions WHERE show=$1 AND shot=$2 AND task=$3 AND version=$4", prj, shot, task, version); err != nil {
-		return Internal{fmt.Errorf("could not delete data from 'versions' table: %w", err)}
+		return Internal(fmt.Errorf("could not delete data from 'versions' table: %w", err))
 	}
 	err = tx.Commit()
 	if err != nil {
-		return Internal{err}
+		return Internal(err)
 	}
 	return nil
 }

--- a/version.go
+++ b/version.go
@@ -77,10 +77,10 @@ func (v *Version) dbValues() []interface{} {
 // AddVersion은 db의 특정 프로젝트, 특정 샷에 태스크를 추가한다.
 func AddVersion(db *sql.DB, prj, shot, task string, v *Version) error {
 	if prj == "" {
-		return fmt.Errorf("show not specified")
+		return BadRequest{"show not specified"}
 	}
 	if shot == "" {
-		return fmt.Errorf("shot not specified")
+		return BadRequest{"shot not specified"}
 	}
 	if task == "" {
 		return fmt.Errorf("task not specified")
@@ -92,19 +92,19 @@ func AddVersion(db *sql.DB, prj, shot, task string, v *Version) error {
 	idxstr := strings.Join(VersionTableIndices, ", ")
 	tx, err := db.Begin()
 	if err != nil {
-		return fmt.Errorf("could not begin a transaction: %v", err)
+		return Internal{fmt.Errorf("could not begin a transaction: %v", err)}
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 	stmt := fmt.Sprintf("INSERT INTO versions (%s) VALUES (%s)", keystr, idxstr)
 	if _, err := tx.Exec(stmt, v.dbValues()...); err != nil {
-		return fmt.Errorf("could not insert versions: %v", err)
+		return Internal{fmt.Errorf("could not insert versions: %v", err)}
 	}
 	if _, err := tx.Exec("UPDATE tasks SET status=$1, last_version=$2 WHERE show=$3 AND shot=$4 AND task=$5", TaskInProgress, v.Version, prj, shot, task); err != nil {
-		return fmt.Errorf("could not update last version of task: %v", err)
+		return Internal{fmt.Errorf("could not update last version of task: %v", err)}
 	}
 	err = tx.Commit()
 	if err != nil {
-		return fmt.Errorf("could not commit the transaction: %v", err)
+		return Internal{fmt.Errorf("could not commit the transaction: %v", err)}
 	}
 	return nil
 }
@@ -152,35 +152,44 @@ func (u UpdateVersionParam) values() []interface{} {
 // UpdateVersion은 db의 특정 태스크를 업데이트 한다.
 func UpdateVersion(db *sql.DB, prj, shot, task string, version string, upd UpdateVersionParam) error {
 	if prj == "" {
-		return fmt.Errorf("show not specified")
+		return BadRequest{"show not specified"}
 	}
 	if shot == "" {
-		return fmt.Errorf("shot not specified")
+		return BadRequest{"shot not specified"}
 	}
 	if task == "" {
-		return fmt.Errorf("task not specified")
+		return BadRequest{"task not specified"}
 	}
 	if version == "" {
-		return fmt.Errorf("version not specified")
+		return BadRequest{"version not specified"}
 	}
 	keystr := strings.Join(upd.keys(), ", ")
 	idxstr := strings.Join(upd.indices(), ", ")
 	stmt := fmt.Sprintf("UPDATE versions SET (%s) = (%s) WHERE show='%s' AND shot='%s' AND task='%s' AND version='%s'", keystr, idxstr, prj, shot, task, version)
 	if _, err := db.Exec(stmt, upd.values()...); err != nil {
-		return err
+		return Internal{err}
 	}
 	return nil
 }
 
 // VersionExist는 db에 해당 태스크가 존재하는지를 검사한다.
 func VersionExist(db *sql.DB, prj, shot, task string, version string) (bool, error) {
+	if prj == "" {
+		return false, BadRequest{"show not specified"}
+	}
+	if shot == "" {
+		return false, BadRequest{"shot not specified"}
+	}
+	if task == "" {
+		return false, BadRequest{"task not specified"}
+	}
 	if version == "" {
-		return false, fmt.Errorf("version not specified")
+		return false, BadRequest{"version not specified"}
 	}
 	stmt := "SELECT version FROM versions WHERE show=$1 AND shot=$2 AND task=$3 AND version=$4 LIMIT 1"
 	rows, err := db.Query(stmt, prj, shot, task, version)
 	if err != nil {
-		return false, err
+		return false, Internal{err}
 	}
 	return rows.Next(), nil
 }
@@ -193,7 +202,7 @@ func versionFromRows(rows *sql.Rows) (*Version, error) {
 		&v.Version, pq.Array(&v.OutputFiles), pq.Array(&v.Images), &v.Mov, &v.WorkFile, &v.Created,
 	)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	return v, nil
 }
@@ -205,7 +214,7 @@ func GetVersion(db *sql.DB, prj, shot, task string, version string) (*Version, e
 	stmt := fmt.Sprintf("SELECT %s FROM versions WHERE show=$1 AND shot=$2 AND task=$3 AND version=$4 LIMIT 1", keystr)
 	rows, err := db.Query(stmt, prj, shot, task, version)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	ok := rows.Next()
 	if !ok {
@@ -221,7 +230,7 @@ func TaskVersions(db *sql.DB, prj, shot, task string) ([]*Version, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM versions WHERE show=$1 AND shot=$2 AND task=$3", keystr)
 	rows, err := db.Query(stmt, prj, shot, task)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	versions := make([]*Version, 0)
 	for rows.Next() {
@@ -240,7 +249,7 @@ func ShotVersions(db *sql.DB, prj, shot string) ([]*Version, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM versions WHERE show=$1 AND shot=$2", keystr)
 	rows, err := db.Query(stmt, prj, shot)
 	if err != nil {
-		return nil, err
+		return nil, Internal{err}
 	}
 	versions := make([]*Version, 0)
 	for rows.Next() {
@@ -259,11 +268,15 @@ func ShotVersions(db *sql.DB, prj, shot string) ([]*Version, error) {
 func DeleteVersion(db *sql.DB, prj, shot, task string, version string) error {
 	tx, err := db.Begin()
 	if err != nil {
-		return fmt.Errorf("could not begin a transaction: %v", err)
+		return Internal{fmt.Errorf("could not begin a transaction: %w", err)}
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 	if _, err := tx.Exec("DELETE FROM versions WHERE show=$1 AND shot=$2 AND task=$3 AND version=$4", prj, shot, task, version); err != nil {
-		return fmt.Errorf("could not delete data from 'versions' table: %v", err)
+		return Internal{fmt.Errorf("could not delete data from 'versions' table: %w", err)}
 	}
-	return tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return Internal{err}
+	}
+	return nil
 }


### PR DESCRIPTION
cmd/roi 서버를 구현하면서 모듈내의 에러를 통일되게 정의할 필요가
있는것을 깨달았다.

roi 패키지에 Error 인터페이스와 이를 구현하는 몇가지 에러 타입을
생성하고 이를 모듈내에서 사용하도록 변경하였다.

roierror 패키지를 만들까 생각도 해보았지만 이 이상 더 복잡하게
만들고 싶지는 않았다.