### PR TITLE
InternalError 타입 삭제

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -22,7 +22,7 @@ func initTestDB() (*sql.DB, error) {
 func testDB() (*sql.DB, error) {
 	db, err := sql.Open("postgres", "postgresql://root@localhost:54545/roi?sslmode=disable")
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	return db, nil
 }

--- a/cmd/roi/handler.go
+++ b/cmd/roi/handler.go
@@ -75,7 +75,7 @@ func mustFields(r *http.Request, keys ...string) error {
 func sessionUser(r *http.Request) (*roi.User, error) {
 	session, err := getSession(r)
 	if err != nil {
-		return nil, roi.Internal(fmt.Errorf("could not get session: %w", err))
+		return nil, fmt.Errorf("could not get session: %w", err)
 	}
 	user := session["userid"]
 	if user == "" {
@@ -87,7 +87,7 @@ func sessionUser(r *http.Request) (*roi.User, error) {
 			// 일반적으로 db에 사용자가 없는 것은 NotFound 에러를 내지만,
 			// 존재하지 않는 사용자가 세션 유저로 등록되어 있는 것은 해킹일 가능성이 높다.
 			// 로그에 남도록 Internal 에러를 내고 %v 포매팅을 사용해 NotFound 타입정보는 지운다.
-			return nil, roi.Internal(fmt.Errorf("warn: invalid session user (malicious attack?): %s: %v", user, err))
+			return nil, fmt.Errorf("warn: invalid session user (malicious attack?): %s: %v", user, err)
 		}
 	}
 	return u, nil
@@ -108,15 +108,15 @@ func saveFormFile(r *http.Request, field string, dst string) error {
 	}
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		return roi.Internal(fmt.Errorf("could not read file data: %w", err))
+		return fmt.Errorf("could not read file data: %w", err)
 	}
 	err = os.MkdirAll(filepath.Dir(dst), 0755)
 	if err != nil {
-		return roi.Internal(fmt.Errorf("could not create directory: %w", err))
+		return fmt.Errorf("could not create directory: %w", err)
 	}
 	err = ioutil.WriteFile(dst, data, 0755)
 	if err != nil {
-		return roi.Internal(fmt.Errorf("could not save file: %w", err))
+		return fmt.Errorf("could not save file: %w", err)
 	}
 	return nil
 }

--- a/cmd/roi/session.go
+++ b/cmd/roi/session.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/securecookie"
-	"github.com/studio2l/roi"
 )
 
 // cookieHandler는 클라이언트 브라우저 세션에 암호화된 쿠키를 저장을 돕는다.
@@ -14,7 +13,7 @@ var cookieHandler *securecookie.SecureCookie
 func setSession(w http.ResponseWriter, session map[string]string) error {
 	encoded, err := cookieHandler.Encode("session", session)
 	if err != nil {
-		return roi.Internal(err)
+		return err
 	}
 	c := &http.Cookie{
 		Name:  "session",

--- a/cmd/roi/shot_handler.go
+++ b/cmd/roi/shot_handler.go
@@ -21,14 +21,14 @@ func addShotHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		// 관련 이슈: #143
 		showRows, err := DB.Query("SELECT show FROM shows")
 		if err != nil {
-			return roi.Internal(err)
+			return err
 		}
 		defer showRows.Close()
 		if !showRows.Next() {
 			return roi.BadRequest("no shows in roi")
 		}
 		if err := showRows.Scan(&show); err != nil {
-			return roi.Internal(err)
+			return err
 		}
 		http.Redirect(w, r, "/add-shot?show="+show, http.StatusSeeOther)
 		return nil

--- a/cmd/roi/template.go
+++ b/cmd/roi/template.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"github.com/studio2l/roi"
 )
 
 // templates에는 사용자에게 보일 페이지의 템플릿이 담긴다.
@@ -24,7 +22,7 @@ func executeTemplate(w http.ResponseWriter, name string, data interface{}) error
 	}
 	err := templates.ExecuteTemplate(w, name, data)
 	if err != nil {
-		return roi.Internal(err)
+		return err
 	}
 	return nil
 }

--- a/cmd/roi/user_handler.go
+++ b/cmd/roi/user_handler.go
@@ -65,7 +65,7 @@ func signupHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		}
 		err = roi.AddUser(DB, env.SessionUser.ID, pw)
 		if err != nil {
-			return roi.Internal(err)
+			return err
 		}
 		session := map[string]string{
 			"userid": id,

--- a/db.go
+++ b/db.go
@@ -20,45 +20,45 @@ func InitDB() (*sql.DB, error) {
 func initDB(addr string) (*sql.DB, error) {
 	db, err := sql.Open("postgres", addr)
 	if err != nil {
-		return nil, Internal(fmt.Errorf("could not open database with root user: %w", err))
+		return nil, fmt.Errorf("could not open database with root user: %w", err)
 	}
 	tx, err := db.Begin()
 	if err != nil {
-		return nil, Internal(fmt.Errorf("could not begin a transaction: %w", err))
+		return nil, fmt.Errorf("could not begin a transaction: %w", err)
 	}
 	defer tx.Rollback() // 트랜잭션이 완료되지 않았을 때만 실행됨
 
 	// 밑의 구문들은 다 여러번 실행해도 안전한 구문들이다.
 	if _, err := tx.Exec("CREATE USER IF NOT EXISTS roiuser"); err != nil {
-		return nil, Internal(fmt.Errorf("could not create user 'roiuser': %w", err))
+		return nil, fmt.Errorf("could not create user 'roiuser': %w", err)
 	}
 	if _, err := tx.Exec("CREATE DATABASE IF NOT EXISTS roi"); err != nil {
-		return nil, Internal(fmt.Errorf("could not create db 'roi': %w", err))
+		return nil, fmt.Errorf("could not create db 'roi': %w", err)
 	}
 	if _, err := tx.Exec("GRANT ALL ON DATABASE roi TO roiuser"); err != nil {
-		return nil, Internal(fmt.Errorf("could not grant 'roi' to 'roiuser': %w", err))
+		return nil, fmt.Errorf("could not grant 'roi' to 'roiuser': %w", err)
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsSitesStmt); err != nil {
-		return nil, Internal(fmt.Errorf("could not create 'sites' table: %w", err))
+		return nil, fmt.Errorf("could not create 'sites' table: %w", err)
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsShowsStmt); err != nil {
-		return nil, Internal(fmt.Errorf("could not create 'projects' table: %w", err))
+		return nil, fmt.Errorf("could not create 'projects' table: %w", err)
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsShotsStmt); err != nil {
-		return nil, Internal(fmt.Errorf("could not create 'shots' table: %w", err))
+		return nil, fmt.Errorf("could not create 'shots' table: %w", err)
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsTasksStmt); err != nil {
-		return nil, Internal(fmt.Errorf("could not create 'tasks' table: %w", err))
+		return nil, fmt.Errorf("could not create 'tasks' table: %w", err)
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsVersionsStmt); err != nil {
-		return nil, Internal(fmt.Errorf("could not create 'versions' table: %w", err))
+		return nil, fmt.Errorf("could not create 'versions' table: %w", err)
 	}
 	if _, err := tx.Exec(CreateTableIfNotExistsUsersStmt); err != nil {
-		return nil, Internal(fmt.Errorf("could not create 'users' table: %w", err))
+		return nil, fmt.Errorf("could not create 'users' table: %w", err)
 	}
 	err = tx.Commit()
 	if err != nil {
-		return nil, Internal(fmt.Errorf("could not commit transaction: %w", err))
+		return nil, fmt.Errorf("could not commit transaction: %w", err)
 	}
 	return db, nil
 }
@@ -67,7 +67,7 @@ func initDB(addr string) (*sql.DB, error) {
 func DB() (*sql.DB, error) {
 	db, err := sql.Open("postgres", "postgresql://roiuser@localhost:26257/roi?sslmode=disable")
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	return db, nil
 }
@@ -92,7 +92,7 @@ func dbKeys(v interface{}) (keys []string, err error) {
 	var field reflect.StructField
 	defer func() {
 		if r := recover(); r != nil {
-			err = Internal(fmt.Errorf("dbKeys: %v: %s.%s", r, typ.Name(), field.Name))
+			err = fmt.Errorf("dbKeys: %v: %s.%s", r, typ.Name(), field.Name)
 		}
 	}()
 	rv := reflect.ValueOf(v)
@@ -121,7 +121,7 @@ func dbValues(v interface{}) (vals []interface{}, err error) {
 	var field reflect.Value
 	defer func() {
 		if r := recover(); r != nil {
-			err = Internal(fmt.Errorf("dbValues: %v: %s.%s", r, typ.Name(), field.Type().Name()))
+			err = fmt.Errorf("dbValues: %v: %s.%s", r, typ.Name(), field.Type().Name())
 		}
 	}()
 	rv := reflect.ValueOf(v)

--- a/error.go
+++ b/error.go
@@ -3,7 +3,9 @@ package roi
 import "net/http"
 
 // Error는 error 인터페이스를 만족하는 roi의 에러 타입이다.
-// roi의 모든 에러는 Error 형이어야 한다.
+// Error는 에러와 함께 HTTP Code 정보를 가지고 있어 서버가 이를
+// 반환할수 있도록 하였다.
+// 서버는 Error가 아닌 기본 에러는 InternalServerError로 생각해야한다.
 type Error interface {
 	Error() string
 	Code() int
@@ -53,33 +55,6 @@ func (e BadRequestError) Code() int {
 
 func (e BadRequestError) Log() string {
 	return ""
-}
-
-// InternalError은 문제가 서버 밖으로 전달되지 않아야 함을 의미하는 에러이다.
-// InternalError은 errors.Wrapper 인터페이스를 만족한다.
-type InternalError struct {
-	err error
-}
-
-// Internal은 InternalError를 반환한다.
-func Internal(err error) InternalError {
-	return InternalError{err}
-}
-
-func (e InternalError) Error() string {
-	return "internal error"
-}
-
-func (e InternalError) Code() int {
-	return http.StatusInternalServerError
-}
-
-func (e InternalError) Log() string {
-	return e.err.Error()
-}
-
-func (e InternalError) Unwrap() error {
-	return e.err
 }
 
 // AuthError는 특정 사용자가 허락되지 않은 행동을 요청했음을 의미하는 에러이다.

--- a/site.go
+++ b/site.go
@@ -45,7 +45,7 @@ func AddSite(db *sql.DB) error {
 	idxs := strings.Join(dbIndices(k), ", ")
 	stmt := fmt.Sprintf("INSERT INTO sites (%s) VALUES (%s) ON CONFLICT DO NOTHING", keys, idxs)
 	if _, err := db.Exec(stmt, v...); err != nil {
-		return Internal(err)
+		return err
 	}
 	return nil
 }
@@ -61,7 +61,7 @@ func UpdateSite(db *sql.DB, s *Site) error {
 	idxs := strings.Join(dbIndices(k), ", ")
 	stmt := fmt.Sprintf("UPDATE sites SET (%s) = (%s) WHERE site='only'", keys, idxs)
 	if _, err := db.Exec(stmt, v...); err != nil {
-		return Internal(err)
+		return err
 	}
 	return nil
 }
@@ -80,7 +80,7 @@ func siteFromRows(rows *sql.Rows) (*Site, error) {
 		pq.Array(&s.Leads),
 	)
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	return s, nil
 }
@@ -96,7 +96,7 @@ func GetSite(db *sql.DB) (*Site, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM sites LIMIT 1", keys)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	ok := rows.Next()
 	if !ok {

--- a/task.go
+++ b/task.go
@@ -119,7 +119,7 @@ func AddTask(db *sql.DB, prj, shot string, t *Task) error {
 	idxs := strings.Join(dbIndices(ks), ", ")
 	stmt := fmt.Sprintf("INSERT INTO tasks (%s) VALUES (%s)", keys, idxs)
 	if _, err := db.Exec(stmt, vs...); err != nil {
-		return Internal(err)
+		return err
 	}
 	return nil
 }
@@ -154,7 +154,7 @@ func UpdateTask(db *sql.DB, prj, shot, task string, upd UpdateTaskParam) error {
 	idxs := strings.Join(dbIndices(ks), ", ")
 	stmt := fmt.Sprintf("UPDATE tasks SET (%s) = (%s) WHERE show='%s' AND shot='%s' AND task='%s'", keys, idxs, prj, shot, task)
 	if _, err := db.Exec(stmt, vs...); err != nil {
-		return Internal(err)
+		return err
 	}
 	return nil
 }
@@ -164,7 +164,7 @@ func TaskExist(db *sql.DB, prj, shot, task string) (bool, error) {
 	stmt := "SELECT task FROM tasks WHERE show=$1 AND shot=$2 AND task=$3 LIMIT 1"
 	rows, err := db.Query(stmt, prj, shot, task)
 	if err != nil {
-		return false, Internal(err)
+		return false, err
 	}
 	return rows.Next(), nil
 }
@@ -178,7 +178,7 @@ func taskFromRows(rows *sql.Rows) (*Task, error) {
 		&t.StartDate, &t.EndDate, &t.DueDate,
 	)
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	return t, nil
 }
@@ -194,7 +194,7 @@ func GetTask(db *sql.DB, prj, shot, task string) (*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks WHERE show=$1 AND shot=$2 AND task=$3 LIMIT 1", keys)
 	rows, err := db.Query(stmt, prj, shot, task)
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	ok := rows.Next()
 	if !ok {
@@ -214,7 +214,7 @@ func ShotTasks(db *sql.DB, prj, shot string) ([]*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks WHERE show=$1 AND shot=$2", keys)
 	rows, err := db.Query(stmt, prj, shot)
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	tasks := make([]*Task, 0)
 	for rows.Next() {
@@ -244,7 +244,7 @@ func UserTasks(db *sql.DB, user string) ([]*Task, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM tasks JOIN shots ON (tasks.show = shots.show AND tasks.shot = shots.shot)  WHERE tasks.assignee='%s' AND tasks.task = ANY(shots.working_tasks)", keys, user)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	tasks := make([]*Task, 0)
 	for rows.Next() {
@@ -278,7 +278,7 @@ func DeleteTask(db *sql.DB, prj, shot, task string) error {
 	}
 	err = tx.Commit()
 	if err != nil {
-		return Internal(err)
+		return err
 	}
 	return nil
 }

--- a/user.go
+++ b/user.go
@@ -85,7 +85,7 @@ func UserExist(db *sql.DB, id string) (bool, error) {
 	stmt := fmt.Sprintf("SELECT id FROM users WHERE id='%s'", id)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return false, Internal(err)
+		return false, err
 	}
 	return rows.Next(), rows.Err()
 }
@@ -99,18 +99,18 @@ func Users(db *sql.DB) ([]*User, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM users", keys)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	us := make([]*User, 0)
 	for rows.Next() {
 		u := &User{}
 		if err := rows.Scan(&u.ID, &u.KorName, &u.Name, &u.Team, &u.Role, &u.Email, &u.PhoneNumber, &u.EntryDate); err != nil {
-			return nil, Internal(err)
+			return nil, err
 		}
 		us = append(us, u)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, Internal(fmt.Errorf("could not scan user: %v", err))
+		return nil, fmt.Errorf("could not scan user: %v", err)
 	}
 	return us, nil
 }
@@ -126,7 +126,7 @@ func GetUser(db *sql.DB, id string) (*User, error) {
 	stmt := fmt.Sprintf("SELECT %s FROM users WHERE id='%s'", keys, id)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	ok := rows.Next()
 	if !ok {
@@ -134,7 +134,7 @@ func GetUser(db *sql.DB, id string) (*User, error) {
 	}
 	u := &User{}
 	if err := rows.Scan(&u.ID, &u.KorName, &u.Name, &u.Team, &u.Role, &u.Email, &u.PhoneNumber, &u.EntryDate); err != nil {
-		return nil, Internal(err)
+		return nil, err
 	}
 	return u, nil
 }
@@ -145,7 +145,7 @@ func UserPasswordMatch(db *sql.DB, id, pw string) (bool, error) {
 	stmt := fmt.Sprintf("SELECT hashed_password FROM users WHERE id='%s'", id)
 	rows, err := db.Query(stmt)
 	if err != nil {
-		return false, Internal(err)
+		return false, err
 	}
 	ok := rows.Next()
 	if !ok {
@@ -209,7 +209,7 @@ func UpdateUser(db *sql.DB, id string, u UpdateUserParam) error {
 	idxstr := strings.Join(u.indices(), ", ")
 	stmt := fmt.Sprintf("UPDATE users SET (%s) = (%s) WHERE id='%s'", keystr, idxstr, id)
 	if _, err := db.Exec(stmt, u.values()...); err != nil {
-		return Internal(err)
+		return err
 	}
 	return nil
 }
@@ -218,12 +218,12 @@ func UpdateUser(db *sql.DB, id string, u UpdateUserParam) error {
 func UpdateUserPassword(db *sql.DB, id, pw string) error {
 	hashed, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost)
 	if err != nil {
-		return Internal(fmt.Errorf("could not generate hash from password: %v", err))
+		return fmt.Errorf("could not generate hash from password: %v", err)
 	}
 	hashed_password := string(hashed)
 	stmt := fmt.Sprintf("UPDATE users SET hashed_password=$1 WHERE id='%s'", id)
 	if _, err := db.Exec(stmt, hashed_password); err != nil {
-		return Internal(err)
+		return err
 	}
 	return nil
 }
@@ -237,7 +237,7 @@ func DeleteUser(db *sql.DB, id string) error {
 	}
 	stmt := fmt.Sprintf("DELETE FROM users WHERE id='%s'", id)
 	if _, err := db.Exec(stmt); err != nil {
-		return Internal(err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
서버에서 HTTP 응답에 에러 메시지를 다 보여주는 대신
"internal error"라는 메시지만 보이도록 InternalError를
사용하려 하였으나, 디버깅을 할 때도 실제 에러를 보여주지 않게되어
InternalError를 제거하고 응답코드 정보가 없는 에러의 경우
InternalServerError로 응답하도록 하였음.