### PR TITLE
site 페이지에 멀티 인풋 적용

### DIFF
--- a/cmd/roi/handler.go
+++ b/cmd/roi/handler.go
@@ -158,3 +158,17 @@ func saveFormFile(r *http.Request, field string, dst string) error {
 	}
 	return nil
 }
+
+// formValues는 http 요청에서 슬라이스 형식의 필드값을 가지고 온다.
+// 그 중 비어있는 값은 슬라이스에서 빠진다.
+// formValues는 요청의 폼 정보를 자동으로 파싱한다.
+func formValues(r *http.Request, field string) []string {
+	r.ParseForm()
+	vals := make([]string, 0)
+	for _, v := range r.Form[field] {
+		if v != "" {
+			vals = append(vals, v)
+		}
+	}
+	return vals
+}

--- a/cmd/roi/site_handler.go
+++ b/cmd/roi/site_handler.go
@@ -26,13 +26,13 @@ func siteHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 
 func sitePostHander(w http.ResponseWriter, r *http.Request, env *Env) error {
 	s := &roi.Site{
-		VFXSupervisors:  fieldSplit(r.FormValue("vfx_supervisors")),
-		VFXProducers:    fieldSplit(r.FormValue("vfx_producers")),
-		CGSupervisors:   fieldSplit(r.FormValue("cg_supervisors")),
-		ProjectManagers: fieldSplit(r.FormValue("project_managers")),
-		Tasks:           fieldSplit(r.FormValue("tasks")),
-		DefaultTasks:    fieldSplit(r.FormValue("default_tasks")),
-		Leads:           fieldSplit(r.FormValue("leads")),
+		VFXSupervisors:  formValues(r, "vfx_supervisors"),
+		VFXProducers:    formValues(r, "vfx_producers"),
+		CGSupervisors:   formValues(r, "cg_supervisors"),
+		ProjectManagers: formValues(r, "project_managers"),
+		Tasks:           formValues(r, "tasks"),
+		DefaultTasks:    formValues(r, "default_tasks"),
+		Leads:           formValues(r, "leads"),
 	}
 	err := roi.UpdateSite(DB, s)
 	if err != nil {

--- a/cmd/roi/static/roi-func.js
+++ b/cmd/roi/static/roi-func.js
@@ -1,3 +1,16 @@
+// appendFieldInput은 가까운 부모 field에 첫번째 인풋과 같은 형식의 새 인풋을 추가한다.
+function appendFieldInput(el) {
+	let field = el.closest(".field")
+	// 숨겨진 첫번째 인풋은 생성될 타입과 이름을 가진 레퍼런스 인풋이다.
+	let refInput = field.getElementsByTagName("input")[0]
+	let input = document.createElement("input")
+	input.type = refInput.type
+	input.name = refInput.name
+	input.value = ""
+	input.style.marginTop = "0.5rem"
+	field.appendChild(input)
+}
+
 // autocomplete takes input tag and possible autocompleted values and label.
 function autocomplete(inp, vals, label) {
 	// turn-off browser's default autocomplete behavior

--- a/cmd/roi/static/roi.css
+++ b/cmd/roi/static/roi.css
@@ -29,6 +29,15 @@ hr {
 	border-top: 1px solid #CCCCCC;
 }
 
+.field > input {
+	margin-top: 0.3rem !important;
+}
+
+
+.field > select {
+	margin-top: 0.3rem !important;
+}
+
 #main {
 	padding: 8px;
 }

--- a/cmd/roi/tmpl/site.html
+++ b/cmd/roi/tmpl/site.html
@@ -5,26 +5,75 @@
 <div class="ui raised very padded text container grey inverted segment">
 	<h2 class="ui dividing header">사이트 설정</h2>
 	<form method="post" class="ui form">
-		<div class="field"><label>VFX 수퍼바이저</label>
-			<input type="text" name="vfx_supervisors" value="{{fieldJoin .Site.VFXSupervisors}}"/>
+		<div class="field">
+			<div style="display:flex;color:black">
+				<label>VFX 수퍼바이저</label>
+				<div style="margin-left:0.5rem;cursor:pointer" onclick="appendFieldInput(this)">+</div>
+			</div>
+			<input hidden type="text" name="vfx_supervisors" value=""/>
+			{{range .Site.VFXSupervisors}}
+			<input type="text" name="vfx_supervisors" value="{{.}}"/>
+			{{end}}
 		</div>
-		<div class="field"><label>VFX 프로듀서</label>
-			<input type="text" name="vfx_producers" value="{{fieldJoin .Site.VFXProducers}}"/>
+		<div class="field">
+			<div style="display:flex;color:black">
+				<label>VFX 프로듀서</label>
+				<div style="margin-left:0.5rem;cursor:pointer" onclick="appendFieldInput(this)">+</div>
+			</div>
+			<input hidden type="text" name="vfx_producers" value=""/>
+			{{range .Site.VFXProducers}}
+			<input type="text" name="vfx_producers" value="{{.}}"/>
+			{{end}}
 		</div>
-		<div class="field"><label>CG 수퍼바이저</label>
-			<input type="text" name="cg_supervisors" value="{{fieldJoin .Site.CGSupervisors}}"/>
+		<div class="field">
+			<div style="display:flex;color:black">
+				<label>CG 수퍼바이저</label>
+				<div style="margin-left:0.5rem;cursor:pointer" onclick="appendFieldInput(this)">+</div>
+			</div>
+			<input hidden type="text" name="cg_supervisors" value=""/>
+			{{range .Site.CGSupervisors}}
+			<input type="text" name="cg_supervisors" value="{{.}}"/>
+			{{end}}
 		</div>
-		<div class="field"><label>프로젝트 매니저</label>
-			<input type="text" name="project_managers" value="{{fieldJoin .Site.ProjectManagers}}"/>
+		<div class="field">
+			<div style="display:flex;color:black">
+				<label>프로젝트 매니저</label>
+				<div style="margin-left:0.5rem;cursor:pointer" onclick="appendFieldInput(this)">+</div>
+			</div>
+			<input hidden type="text" name="project_managers" value=""/>
+			{{range .Site.ProjectManagers}}
+			<input type="text" name="project_managers" value="{{.}}"/>
+			{{end}}
 		</div>
-		<div class="field"><label>태스크</label>
-			<input type="text" name="tasks" value="{{fieldJoin .Site.Tasks}}"/>
+		<div class="field">
+			<div style="display:flex;color:black">
+				<label>태스크</label>
+				<div style="margin-left:0.5rem;cursor:pointer" onclick="appendFieldInput(this)">+</div>
+			</div>
+			<input hidden type="text" name="tasks" value=""/>
+			{{range .Site.Tasks}}
+			<input type="text" name="tasks" value="{{.}}"/>
+			{{end}}
 		</div>
-		<div class="field"><label>기본 태스크</label>
-			<input type="text" name="default_tasks" value="{{fieldJoin .Site.DefaultTasks}}"/>
+		<div class="field">
+			<div style="display:flex;color:black">
+				<label>기본 태스크</label>
+				<div style="margin-left:0.5rem;cursor:pointer" onclick="appendFieldInput(this)">+</div>
+			</div>
+			<input hidden type="text" name="default_tasks" value=""/>
+			{{range .Site.DefaultTasks}}
+			<input type="text" name="default_tasks" value="{{.}}"/>
+			{{end}}
 		</div>
-		<div class="field"><label>리드</label>
-			<input type="text" name="leads" value="{{fieldJoin .Site.Leads}}"/>
+		<div class="field">
+			<div style="display:flex;color:black">
+				<label>리드</label>
+				<div style="margin-left:0.5rem;cursor:pointer" onclick="appendFieldInput(this)">+</div>
+			</div>
+			<input hidden type="text" name="leads" value=""/>
+			{{range .Site.Leads}}
+			<input type="text" name="leads" value="{{.}}"/>
+			{{end}}
 		</div>
 		<button class="ui button green" type="submit" value="Submit">수정</button>
 	</form>


### PR DESCRIPTION
기존에는 콤마(,)를 이용해서 인풋을 나누었는데 이 방법이
여러 항목이 들어가거나, 긴 문자열의 항목들이 들어가면
수정이 불편했다. 또한 입력시 사용자를 찾아주는 스크립트를
적용하기도 어려운 형식이라 멀티 인풋을 사용하였다.

지금은 site 페이지에만 적용했지만 앞으로 다른 페이지에서도
한 필드안에 여러 인풋을 받아야 하는 곳에 사용할 예정이다.