### PR TITLE
쇼 생성할 때 POST 핸들러에서 기본 태스크를 추가해주어야 한다

### DIFF
--- a/cmd/roi/show_handler.go
+++ b/cmd/roi/show_handler.go
@@ -30,19 +30,10 @@ func addShowHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 	if r.Method == "POST" {
 		return addShowPostHandler(w, r, env)
 	}
-	si, err := roi.GetSite(DB)
-	if err != nil {
-		return err
-	}
-	s := &roi.Show{
-		DefaultTasks: si.DefaultTasks,
-	}
 	recipe := struct {
 		LoggedInUser string
-		Show         *roi.Show
 	}{
 		LoggedInUser: env.SessionUser.ID,
-		Show:         s,
 	}
 	return executeTemplate(w, "add-show.html", recipe)
 }
@@ -59,8 +50,13 @@ func addShowPostHandler(w http.ResponseWriter, r *http.Request, env *Env) error 
 	} else if !errors.As(err, &roi.NotFoundError{}) {
 		return err
 	}
+	si, err := roi.GetSite(DB)
+	if err != nil {
+		return err
+	}
 	s := &roi.Show{
-		Show: show,
+		Show:         show,
+		DefaultTasks: si.DefaultTasks,
 	}
 	err = roi.AddShow(DB, s)
 	if err != nil {


### PR DESCRIPTION
기존에는 쇼 생성 페이지에서 기본 태스크를 설정해주는 구조였지만
이제는 이름밖에 받아들이지 않기 때문에 POST에서 처리되어야 한다.