### PR TITLE
dbExec 오버헤드 체크를 위한 벤치마크 추가

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,45 @@
+package roi
+
+import "testing"
+
+func BenchmarkDBExecStmt(b *testing.B) {
+	db, err := testDB()
+	if err != nil {
+		b.Fatalf("could not open db: %w", err)
+	}
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS bench (val INT)")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_, err = db.Exec("TRUNCATE TABLE bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		_, err := db.Exec("INSERT INTO bench (val) VALUES ($1)", i)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDBExecFunc(b *testing.B) {
+	db, err := testDB()
+	if err != nil {
+		b.Fatalf("could not open db: %w", err)
+	}
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS bench (val INT)")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_, err = db.Exec("TRUNCATE TABLE bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		err := dbExec(db, []dbStatement{dbStmt("INSERT INTO bench (val) VALUES ($1)", i)})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
최근에 트랜잭션을 사용하는 dbExec 함수를 추가한 후
이를 db.Exec를 사용하는 모든 장소에 대신 적용하기 전에 얼마나
오버헤드가 심한지 벤치마크를 추가해 보았다 아래는 그 결과이다.

BenchmarkDBExecStmt 	    1311	    820629 ns/op
BenchmarkDBExecFunc 	     582	   2029714 ns/op

1.2ms 정도의 차이가 발생한다. 프로그램 속도에 그리 영향을 미치지
않을 것임을 확인하였다.