### PR TITLE
disabled 된 인풋을 readonly로 변경

### DIFF
--- a/cmd/roi/static/roi.css
+++ b/cmd/roi/static/roi.css
@@ -90,3 +90,11 @@ hr {
 	margin-left: 0.5rem;
 	cursor:pointer;
 }
+
+input:read-only {
+	background-color: #BBBBBB !important;
+}
+
+input:-moz-read-only {
+	background-color: #BBBBBB !important;
+}

--- a/cmd/roi/tmpl/add-shot.html
+++ b/cmd/roi/tmpl/add-shot.html
@@ -5,8 +5,8 @@
 <div class="ui raised very padded text container grey inverted segment">
 	<h2 class="ui dividing header">샷 추가</h2>
 	<form method="post" class="ui form">
-		<div class="field disabled"><label>쇼</label>
-			<input type="text" name="show" value="{{.Show.Show}}"/>
+		<div class="field"><label>쇼</label>
+			<input readonly type="text" name="show" value="{{.Show.Show}}"/>
 		</div>
 		<div class="field"><label>샷</label>
 			<input type="text" name="shot" value=""/>

--- a/cmd/roi/tmpl/add-version.html
+++ b/cmd/roi/tmpl/add-version.html
@@ -7,14 +7,14 @@
 		버전 생성
 	</h2>
 	<form method="post" class="ui form" enctype="multipart/form-data">
-		<div class="field disabled"><label>프로젝트</label>
-			<input type="text" name="show" value="{{.Version.Show}}"/>
+		<div class="field"><label>프로젝트</label>
+			<input readonly type="text" name="show" value="{{.Version.Show}}"/>
 		</div>
-		<div class="field disabled"><label>샷</label>
-			<input type="text" name="shot" value="{{.Version.Shot}}"/>
+		<div class="field"><label>샷</label>
+			<input readonly type="text" name="shot" value="{{.Version.Shot}}"/>
 		</div>
-		<div class="field disabled"><label>태스크</label>
-			<input type="text" name="task" value="{{.Version.Task}}"/>
+		<div class="field"><label>태스크</label>
+			<input readonly type="text" name="task" value="{{.Version.Task}}"/>
 		</div>
 		<div class="field"><label>버전</label>
 			<input type="text" name="version" value="{{.Version.Version}}" autofocus />

--- a/cmd/roi/tmpl/update-shot.html
+++ b/cmd/roi/tmpl/update-shot.html
@@ -5,11 +5,11 @@
 <div class="ui raised very padded text container grey inverted segment">
 	<h2 class="ui dividing header">샷 수정</h2>
 	<form method="post" class="ui form" enctype="multipart/form-data">
-		<div class="field disabled"><label>프로젝트</label>
-			<input type="text" name="show" value="{{.Shot.Show}}"/>
+		<div class="field"><label>프로젝트</label>
+			<input readonly type="text" name="show" value="{{.Shot.Show}}"/>
 		</div>
-		<div class="field disabled"><label>아이디</label>
-			<input type="text" name="shot" value="{{.Shot.Shot}}"/>
+		<div class="field"><label>아이디</label>
+			<input readonly type="text" name="shot" value="{{.Shot.Shot}}"/>
 		</div>
 		<div class="field"><label>썸네일</label>
 			{{if hasThumbnail $.Shot.Show $.Shot.Shot}}<img width="288px" height="162px" src="{{$.Thumbnail}}"></img>{{end}}

--- a/cmd/roi/tmpl/update-show.html
+++ b/cmd/roi/tmpl/update-show.html
@@ -5,8 +5,8 @@
 <div class="ui raised very padded text container grey inverted segment">
 	<h2 class="ui dividing header">프로젝트 설정</h2>
 	<form method="post" class="ui form">
-		<div class="field disabled"><label>아이디</label>
-			<input type="text" name="show" value="{{.Show.Show}}"/>
+		<div class="field"><label>아이디</label>
+			<input readonly type="text" name="show" value="{{.Show.Show}}"/>
 		</div>
 		<div class="field"><label>상태</label>
 			<select type="text" name="status">

--- a/cmd/roi/tmpl/update-task.html
+++ b/cmd/roi/tmpl/update-task.html
@@ -5,14 +5,14 @@
 <div class="ui raised very padded text container grey inverted segment">
 	<h2 class="ui dividing header">태스크 수정</h2>
 	<form method="post" class="ui form">
-		<div class="field disabled"><label>프로젝트</label>
-			<input type="text" name="show" value="{{.Task.Show}}"/>
+		<div class="field"><label>프로젝트</label>
+			<input readonly type="text" name="show" value="{{.Task.Show}}"/>
 		</div>
-		<div class="field disabled"><label>샷</label>
-			<input type="text" name="shot" value="{{.Task.Shot}}"/>
+		<div class="field"><label>샷</label>
+			<input readonly type="text" name="shot" value="{{.Task.Shot}}"/>
 		</div>
-		<div class="field disabled"><label>태스크</label>
-			<input type="text" name="name" value="{{.Task.Task}}"/>
+		<div class="field"><label>태스크</label>
+			<input readonly type="text" name="name" value="{{.Task.Task}}"/>
 		</div>
 		<div class="field"><label>마감일</label>
 			<input type="date" name="due_date" value="{{stringFromDate $.Task.DueDate}}">

--- a/cmd/roi/tmpl/update-version.html
+++ b/cmd/roi/tmpl/update-version.html
@@ -8,27 +8,23 @@
 	</h2>
 	{{with $v := $.Version}}
 	<form method="post" class="ui form" enctype="multipart/form-data">
-		<div class="field disabled"><label>프로젝트</label>
-			<input type="text" name="show" value="{{$v.Show}}"/>
+		<div class="field"><label>프로젝트</label>
+			<input readonly type="text" name="show" value="{{$v.Show}}"/>
 		</div>
-		<div class="field disabled"><label>샷</label>
-			<input type="text" name="shot" value="{{$v.Shot}}"/>
+		<div class="field"><label>샷</label>
+			<input readonly type="text" name="shot" value="{{$v.Shot}}"/>
 		</div>
-		<div class="field disabled"><label>태스크</label>
-			<input type="text" name="task" value="{{$v.Task}}"/>
+		<div class="field"><label>태스크</label>
+			<input readonly type="text" name="task" value="{{$v.Task}}"/>
 		</div>
-		<div class="field disabled"><label>버전</label>
-			<input type="text" name="version" value="{{$v.Version}}" />
+		<div class="field"><label>버전</label>
+			<input readonly type="text" name="version" value="{{$v.Version}}" />
 		</div>
-		<div class="field disabled"><label>소유자</label>
-			<input type="text" name="owner" value="{{$v.Owner}}" />
+		<div class="field"><label>소유자</label>
+			<input readonly type="text" name="owner" value="{{$v.Owner}}" />
 		</div>
-		<div class="field disabled"><label>상태</label>
-			<select type="text" name="status">
-				{{range $vs := $.AllVersionStatus}}
-				<option value="{{$vs}}" {{if eq $vs $v.Status}}selected{{end}}>{{$vs.UIString}}</option>
-				{{end}}
-			</select>
+		<div class="field"><label>상태</label>
+			<input readonly type="text" name="status" value="{{$v.Status.UIString}}" />
 		</div>
 		<div class="field"><label>프리뷰 이미지</label>
 			<input type="text" name="images" value="{{fieldJoin $v.Images}}"/>


### PR DESCRIPTION
기존에는 상단의 div에 적용되어 있었는데 readonly 속성의 경우
인풋에만 적용할 수 있어 인풋에 적용.

버전의 상태에 적용되어 있던 select는 readonly를 적용할 수 없어
인풋으로 변경하였음.
(어차피 현재 상태를 보이기만 할 거라 괜찮다고 판단함.)