### PR TITLE
roi server 실행시 포트를 정하지 않아도 포트 포워딩이 일어나도록 함

### DIFF
--- a/cmd/roi/server_main.go
+++ b/cmd/roi/server_main.go
@@ -54,7 +54,7 @@ ex) localhost:80:443
 when only one port is specified, the port will be used for current protocol.
 ex) localhost:80, localhost:443
 
-when no port is specified, default port for current protocol will be used.
+when no port is specified, it is same as :80:443.
 ex) localhost
 
 `)
@@ -179,6 +179,10 @@ ex) localhost
 			httpsPort = addrs[2]
 		} else if len(addrs) == 2 {
 			httpsPort = addrs[1]
+		} else if len(addrs) == 1 {
+			portForwarding = true
+			httpPort = "80"
+			httpsPort = "443"
 		}
 	}
 	if site == "" {
@@ -206,6 +210,7 @@ ex) localhost
 		log.Fatal(http.ListenAndServe(site+":"+httpPort, mux))
 	} else {
 		if portForwarding {
+			log.Printf("http(:%s) request will redirected to https(:%s)", httpPort, httpsPort)
 			go func() {
 				log.Fatal(http.ListenAndServe(site+":"+httpPort, http.HandlerFunc(redirectToHttps)))
 			}()


### PR DESCRIPTION
lazyd.org에서 코딩을 시작하고 나서 계속 http 접근이 되지 않아
포트 포워딩을 구현하지 않았는줄 알았는데, 이미 구현이 되어있고
실행시 주소만 적고 포트를 적지 않아서 생긴 문제였음.

포트 포워딩을 원하지 않는 경우가 훨씬 적을 것 같기 때문에 기본
적용되도록 하였음.