### PR TITLE
각 항목에 아이디를 반환하는 ID 메소드 추가

### DIFF
--- a/show.go
+++ b/show.go
@@ -56,6 +56,11 @@ type Show struct {
 	DefaultTasks []string `db:"default_tasks"`
 }
 
+// ID는 Show의 고유 아이디이다. 다른 어떤 항목도 같은 아이디를 가지지 않는다.
+func (s *Show) ID() string {
+	return s.Show
+}
+
 var reValidShow = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 
 func IsValidShow(id string) bool {

--- a/task.go
+++ b/task.go
@@ -45,6 +45,11 @@ type Task struct {
 	PublishVersion string `db:"publish_version"`
 }
 
+// ID는 Task의 고유 아이디이다. 다른 어떤 항목도 같은 아이디를 가지지 않는다.
+func (t *Task) ID() string {
+	return t.Show + "/" + t.Shot + "/" + t.Task
+}
+
 // AddTask는 db의 특정 프로젝트, 특정 샷에 태스크를 추가한다.
 func AddTask(db *sql.DB, show, shot string, t *Task) error {
 	if t == nil {

--- a/version.go
+++ b/version.go
@@ -44,6 +44,11 @@ type Version struct {
 	EndDate     time.Time     `db:"end_date"`     // 버전 작업 마감 시간
 }
 
+// ID는 Version의 고유 아이디이다. 다른 어떤 항목도 같은 아이디를 가지지 않는다.
+func (v *Version) ID() string {
+	return v.Show + "/" + v.Shot + "/" + v.Task + "/" + v.Version
+}
+
 // AddVersion은 db의 특정 프로젝트, 특정 샷에 태스크를 추가한다.
 func AddVersion(db *sql.DB, show, shot, task string, v *Version) error {
 	if v == nil {


### PR DESCRIPTION
또 기존에 혼용해서 쓰이던 아이디와 이름의 경계를 명확히 함.

추후 쇼, 샷, 태스크, 버전 등을 따로 인수로 받던 함수들이
아이디로 통일해서 받아들이도록 할 예정.

이렇게 함으로서 코드도 정리되고 XXX(ids []string) 처럼 여러 항목을
한번에 처리하는 함수를 만들수 있다.