### PR TITLE
{...}UpdateParam을 없애고 Update{...} 함수가 해당 항목을 받도록 함

### DIFF
--- a/cmd/roi/shot_handler.go
+++ b/cmd/roi/shot_handler.go
@@ -154,19 +154,22 @@ func updateShotPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 	if err != nil {
 		return err
 	}
-	upd := roi.UpdateShotParam{
-		Status:        roi.ShotStatus(r.FormValue("status")),
-		EditOrder:     atoi(r.FormValue("edit_order")),
-		Description:   r.FormValue("description"),
-		CGDescription: r.FormValue("cg_description"),
-		TimecodeIn:    r.FormValue("timecode_in"),
-		TimecodeOut:   r.FormValue("timecode_out"),
-		Duration:      atoi(r.FormValue("duration")),
-		Tags:          fieldSplit(r.FormValue("tags")),
-		WorkingTasks:  tasks,
-		DueDate:       tforms["due_date"],
+	s, err := roi.GetShot(DB, id)
+	if err != nil {
+		return err
 	}
-	err = roi.UpdateShot(DB, id, upd)
+	s.Status = roi.ShotStatus(r.FormValue("status"))
+	s.EditOrder = atoi(r.FormValue("edit_order"))
+	s.Description = r.FormValue("description")
+	s.CGDescription = r.FormValue("cg_description")
+	s.TimecodeIn = r.FormValue("timecode_in")
+	s.TimecodeOut = r.FormValue("timecode_out")
+	s.Duration = atoi(r.FormValue("duration"))
+	s.Tags = fieldSplit(r.FormValue("tags"))
+	s.WorkingTasks = tasks
+	s.DueDate = tforms["due_date"]
+
+	err = roi.UpdateShot(DB, id, s)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/show_handler.go
+++ b/cmd/roi/show_handler.go
@@ -115,25 +115,28 @@ func updateShowPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 	if err != nil {
 		return err
 	}
-	upd := roi.UpdateShowParam{
-		Name:          r.FormValue("name"),
-		Status:        r.FormValue("status"),
-		Client:        r.FormValue("client"),
-		Director:      r.FormValue("director"),
-		Producer:      r.FormValue("producer"),
-		VFXSupervisor: r.FormValue("vfx_supervisor"),
-		VFXManager:    r.FormValue("vfx_manager"),
-		CGSupervisor:  r.FormValue("cg_supervisor"),
-		StartDate:     timeForms["start_date"],
-		ReleaseDate:   timeForms["release_date"],
-		CrankIn:       timeForms["crank_in"],
-		CrankUp:       timeForms["crank_up"],
-		VFXDueDate:    timeForms["vfx_due_date"],
-		OutputSize:    r.FormValue("output_size"),
-		ViewLUT:       r.FormValue("view_lut"),
-		DefaultTasks:  fieldSplit(r.FormValue("default_tasks")),
+	s, err := roi.GetShow(DB, id)
+	if err != nil {
+		return err
 	}
-	err = roi.UpdateShow(DB, id, upd)
+	s.Name = r.FormValue("name")
+	s.Status = r.FormValue("status")
+	s.Client = r.FormValue("client")
+	s.Director = r.FormValue("director")
+	s.Producer = r.FormValue("producer")
+	s.VFXSupervisor = r.FormValue("vfx_supervisor")
+	s.VFXManager = r.FormValue("vfx_manager")
+	s.CGSupervisor = r.FormValue("cg_supervisor")
+	s.StartDate = timeForms["start_date"]
+	s.ReleaseDate = timeForms["release_date"]
+	s.CrankIn = timeForms["crank_in"]
+	s.CrankUp = timeForms["crank_up"]
+	s.VFXDueDate = timeForms["vfx_due_date"]
+	s.OutputSize = r.FormValue("output_size")
+	s.ViewLUT = r.FormValue("view_lut")
+	s.DefaultTasks = fieldSplit(r.FormValue("default_tasks"))
+
+	err = roi.UpdateShow(DB, id, s)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/task_handler.go
+++ b/cmd/roi/task_handler.go
@@ -68,12 +68,15 @@ func updateTaskPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 			return err
 		}
 	}
-	upd := roi.UpdateTaskParam{
-		Status:   roi.TaskStatus(r.FormValue("status")),
-		Assignee: assignee,
-		DueDate:  tforms["due_date"],
+	t, err := roi.GetTask(DB, id)
+	if err != nil {
+		return err
 	}
-	err = roi.UpdateTask(DB, id, upd)
+	t.Status = roi.TaskStatus(r.FormValue("status"))
+	t.Assignee = assignee
+	t.DueDate = tforms["due_date"]
+
+	err = roi.UpdateTask(DB, id, t)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/user_handler.go
+++ b/cmd/roi/user_handler.go
@@ -83,16 +83,19 @@ func signupHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 // profileHandler는 /profile 페이지로 사용자가 접속했을 때 사용자 프로필 페이지를 반환한다.
 func profileHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 	if r.Method == "POST" {
-		upd := roi.UpdateUserParam{
-			KorName:     r.FormValue("kor_name"),
-			Name:        r.FormValue("name"),
-			Team:        r.FormValue("team"),
-			Role:        r.FormValue("position"),
-			Email:       r.FormValue("email"),
-			PhoneNumber: r.FormValue("phone_number"),
-			EntryDate:   r.FormValue("entry_date"),
+		u, err := roi.GetUser(DB, env.SessionUser.ID)
+		if err != nil {
+			return err
 		}
-		err := roi.UpdateUser(DB, env.SessionUser.ID, upd)
+		u.KorName = r.FormValue("kor_name")
+		u.Name = r.FormValue("name")
+		u.Team = r.FormValue("team")
+		u.Role = r.FormValue("position")
+		u.Email = r.FormValue("email")
+		u.PhoneNumber = r.FormValue("phone_number")
+		u.EntryDate = r.FormValue("entry_date")
+
+		err = roi.UpdateUser(DB, env.SessionUser.ID, u)
 		if err != nil {
 			return err
 		}

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -120,14 +120,17 @@ func updateVersionPostHandler(w http.ResponseWriter, r *http.Request, env *Env) 
 	if err != nil {
 		return err
 	}
-	u := roi.UpdateVersionParam{
-		OutputFiles: fieldSplit(r.FormValue("output_files")),
-		Images:      fieldSplit(r.FormValue("images")),
-		WorkFile:    r.FormValue("work_file"),
-		StartDate:   timeForms["start_date"],
-		EndDate:     timeForms["end_date"],
+	v, err := roi.GetVersion(DB, id)
+	if err != nil {
+		return err
 	}
-	err = roi.UpdateVersion(DB, id, u)
+	v.OutputFiles = fieldSplit(r.FormValue("output_files"))
+	v.Images = fieldSplit(r.FormValue("images"))
+	v.WorkFile = r.FormValue("work_file")
+	v.StartDate = timeForms["start_date"]
+	v.EndDate = timeForms["end_date"]
+
+	err = roi.UpdateVersion(DB, id, v)
 	if err != nil {
 		return err
 	}

--- a/shot.go
+++ b/shot.go
@@ -307,35 +307,20 @@ func SearchShots(db *sql.DB, show string, shots []string, tag, status, task, ass
 	return ss, nil
 }
 
-// UpdateShotParam은 Shot에서 일반적으로 업데이트 되어야 하는 멤버의 모음이다.
-// UpdateShot에서 사용한다.
-type UpdateShotParam struct {
-	Status        ShotStatus `db:"status"`
-	EditOrder     int        `db:"edit_order"`
-	Description   string     `db:"description"`
-	CGDescription string     `db:"cg_description"`
-	TimecodeIn    string     `db:"timecode_in"`
-	TimecodeOut   string     `db:"timecode_out"`
-	Duration      int        `db:"duration"`
-	Tags          []string   `db:"tags"`
-	WorkingTasks  []string   `db:"working_tasks"`
-	DueDate       time.Time  `db:"due_date"`
-}
-
 // UpdateShot은 db에서 해당 샷을 수정한다.
-func UpdateShot(db *sql.DB, id string, upd UpdateShotParam) error {
+// 이 함수를 호출하기 전 해당 샷이 존재하는지 사용자가 검사해야 한다.
+func UpdateShot(db *sql.DB, id string, s *Shot) error {
+	if s == nil {
+		return fmt.Errorf("nil shot")
+	}
 	show, shot, err := SplitShotID(id)
 	if err != nil {
 		return err
 	}
-	if !isValidShotStatus(upd.Status) {
-		return BadRequest(fmt.Sprintf("invalid shot status: '%s'", upd.Status))
+	if !isValidShotStatus(s.Status) {
+		return BadRequest(fmt.Sprintf("invalid shot status: '%s'", s.Status))
 	}
-	_, err = GetShot(db, id)
-	if err != nil {
-		return err
-	}
-	ks, is, vs, err := dbKIVs(upd)
+	ks, is, vs, err := dbKIVs(s)
 	if err != nil {
 		return err
 	}

--- a/shot_test.go
+++ b/shot_test.go
@@ -106,9 +106,9 @@ func TestShot(t *testing.T) {
 	}
 
 	for _, s := range want {
-		err = UpdateShot(db, s.ID(), UpdateShotParam{Status: ShotWaiting})
+		err = UpdateShot(db, s.ID(), s)
 		if err != nil {
-			t.Fatalf("could not clear(update) shot: %s", err)
+			t.Fatalf("could not update shot: %s", err)
 		}
 		err = DeleteShot(db, s.ID())
 		if err != nil {

--- a/show.go
+++ b/show.go
@@ -88,37 +88,16 @@ func AddShow(db *sql.DB, p *Show) error {
 	return nil
 }
 
-// UpdateShowParam은 Show에서 일반적으로 업데이트 되어야 하는 멤버의 모음이다.
-// UpdateShow에서 사용한다.
-type UpdateShowParam struct {
-	Name          string    `db:"name"`
-	Status        string    `db:"status"`
-	Client        string    `db:"client"`
-	Director      string    `db:"director"`
-	Producer      string    `db:"producer"`
-	VFXSupervisor string    `db:"vfx_supervisor"`
-	VFXManager    string    `db:"vfx_manager"`
-	CGSupervisor  string    `db:"cg_supervisor"`
-	CrankIn       time.Time `db:"crank_in"`
-	CrankUp       time.Time `db:"crank_up"`
-	StartDate     time.Time `db:"start_date"`
-	ReleaseDate   time.Time `db:"release_date"`
-	VFXDueDate    time.Time `db:"vfx_due_date"`
-	OutputSize    string    `db:"output_size"`
-	ViewLUT       string    `db:"view_lut"`
-	DefaultTasks  []string  `db:"default_tasks"`
-}
-
 // UpdateShow는 db의 쇼 정보를 수정한다.
-func UpdateShow(db *sql.DB, show string, upd UpdateShowParam) error {
-	_, err := GetShow(db, show)
-	if err != nil {
-		return err
+// 이 함수를 호출하기 전 해당 쇼가 존재하는지 사용자가 검사해야 한다.
+func UpdateShow(db *sql.DB, show string, s *Show) error {
+	if s == nil {
+		return fmt.Errorf("nil show")
 	}
 	if !IsValidShow(show) {
 		return BadRequest(fmt.Sprintf("invalid show id: %s", show))
 	}
-	ks, is, vs, err := dbKIVs(upd)
+	ks, is, vs, err := dbKIVs(s)
 	if err != nil {
 		return err
 	}

--- a/show_test.go
+++ b/show_test.go
@@ -50,9 +50,9 @@ func TestShow(t *testing.T) {
 	if !reflect.DeepEqual(gotAll, wantAll) {
 		t.Fatalf("got: %v, want: %v", gotAll, wantAll)
 	}
-	err = UpdateShow(db, testShow.ID(), UpdateShowParam{})
+	err = UpdateShow(db, testShow.ID(), testShow)
 	if err != nil {
-		t.Fatalf("could not clear(update) project: %s", err)
+		t.Fatalf("could not update project: %s", err)
 	}
 	err = DeleteShow(db, testShow.ID())
 	if err != nil {

--- a/task.go
+++ b/task.go
@@ -106,28 +106,20 @@ func AddTask(db *sql.DB, t *Task) error {
 	return nil
 }
 
-// UpdateTaskParam은 Task에서 일반적으로 업데이트 되어야 하는 멤버의 모음이다.
-// UpdateTask에서 사용한다.
-type UpdateTaskParam struct {
-	Status   TaskStatus `db:"status"`
-	Assignee string     `db:"assignee"`
-	DueDate  time.Time  `db:"due_date"`
-}
-
 // UpdateTask는 db의 특정 태스크를 업데이트 한다.
-func UpdateTask(db *sql.DB, id string, upd UpdateTaskParam) error {
+// 이 함수를 호출하기 전 해당 태스크가 존재하는지 사용자가 검사해야 한다.
+func UpdateTask(db *sql.DB, id string, t *Task) error {
+	if t == nil {
+		return fmt.Errorf("nil task")
+	}
 	show, shot, task, err := SplitTaskID(id)
 	if err != nil {
 		return err
 	}
-	if !isValidTaskStatus(upd.Status) {
-		return BadRequest(fmt.Sprintf("invalid task status: '%s'", upd.Status))
+	if !isValidTaskStatus(t.Status) {
+		return BadRequest(fmt.Sprintf("invalid task status: '%s'", t.Status))
 	}
-	_, err = GetTask(db, id)
-	if err != nil {
-		return err
-	}
-	ks, is, vs, err := dbKIVs(upd)
+	ks, is, vs, err := dbKIVs(t)
 	if err != nil {
 		return err
 	}

--- a/user.go
+++ b/user.go
@@ -153,20 +153,12 @@ func UserPasswordMatch(db *sql.DB, id, pw string) (bool, error) {
 	return true, nil
 }
 
-// UpdateUserParam은 User에서 일반적으로 업데이트 되어야 하는 멤버의 모음이다.
-// UpdateUser에서 사용한다.
-type UpdateUserParam struct {
-	KorName     string `db:"kor_name"`
-	Name        string `db:"name"`
-	Team        string `db:"team"`
-	Role        string `db:"role"`
-	Email       string `db:"email"`
-	PhoneNumber string `db:"phone_number"`
-	EntryDate   string `db:"entry_date"`
-}
-
-// UpdateUser는 db에 비밀번호를 제외한 사용자 필드를 업데이트 한다.
-func UpdateUser(db *sql.DB, id string, u UpdateUserParam) error {
+// UpdateUser는 db에 비밀번호를 제외한 유저 필드를 업데이트 한다.
+// 이 함수를 호출하기 전 해당 유저가 존재하는지를 사용자가 검사해야한다.
+func UpdateUser(db *sql.DB, id string, u *User) error {
+	if u == nil {
+		return fmt.Errorf("nil user")
+	}
 	if id == "" {
 		return errors.New("empty id")
 	}

--- a/user_test.go
+++ b/user_test.go
@@ -26,16 +26,7 @@ func TestUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not add user: %s", err)
 	}
-	upd := UpdateUserParam{
-		KorName:     "김용빈",
-		Name:        "kim yongbin",
-		Team:        "rnd",
-		Role:        "평민",
-		Email:       "kybinz@gmail.com",
-		PhoneNumber: "010-0000-0000",
-		EntryDate:   "2018-03-02",
-	}
-	err = UpdateUser(db, u.ID, upd) // 실제로 수정한 것은 없음
+	err = UpdateUser(db, u.ID, u)
 	if err != nil {
 		t.Fatalf("could not update user: %v", err)
 	}

--- a/version.go
+++ b/version.go
@@ -108,28 +108,17 @@ func AddVersion(db *sql.DB, v *Version) error {
 	return dbExec(db, stmts)
 }
 
-// UpdateVersionParam은 Version에서 일반적으로 업데이트 되어야 하는 멤버의 모음이다.
-// UpdateVersion에서 사용한다.
-type UpdateVersionParam struct {
-	OutputFiles []string  `db:"output_files"`
-	Images      []string  `db:"images"`
-	Mov         string    `db:"mov"`
-	WorkFile    string    `db:"work_file"`
-	StartDate   time.Time `db:"start_date"`
-	EndDate     time.Time `db:"end_date"`
-}
-
 // UpdateVersion은 db의 특정 태스크를 업데이트 한다.
-func UpdateVersion(db *sql.DB, id string, upd UpdateVersionParam) error {
+// 이 함수를 호출하기 전 해당 태스크가 존재하는지 사용자가 검사해야 한다.
+func UpdateVersion(db *sql.DB, id string, v *Version) error {
+	if v == nil {
+		return fmt.Errorf("nil version")
+	}
 	show, shot, task, version, err := SplitVersionID(id)
 	if err != nil {
 		return err
 	}
-	_, err = GetVersion(db, id)
-	if err != nil {
-		return err
-	}
-	ks, is, vs, err := dbKIVs(upd)
+	ks, is, vs, err := dbKIVs(v)
 	if err != nil {
 		return err
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -67,9 +67,9 @@ func TestVersion(t *testing.T) {
 	if len(taskVersions) != 1 {
 		t.Fatalf("task should have 1 version at this time.")
 	}
-	err = UpdateVersion(db, testVersionA.ID(), UpdateVersionParam{})
+	err = UpdateVersion(db, testVersionA.ID(), testVersionA)
 	if err != nil {
-		t.Fatalf("could not clear(update) version: %v", err)
+		t.Fatalf("could not update version: %v", err)
 	}
 	err = DeleteVersion(db, testVersionA.ID())
 	if err != nil {


### PR DESCRIPTION
Update 함수들만 Param을 이용했던 것이 코드의 복잡성을 증가시키지만
편리하지 않았고, 점점 항목을 수정하는 방식이 늘어나는데 있어
이를 유연하게 처리하기 어렵게 만들었다.