### PR TITLE
항목을 추가하거나 업데이트 전 verify{...} 함수를 통해 유효성 검사

### DIFF
--- a/cmd/roi/api.go
+++ b/cmd/roi/api.go
@@ -92,10 +92,6 @@ func addShotApiHandler(w http.ResponseWriter, r *http.Request) {
 		apiBadRequest(w, fmt.Errorf("'shot' not specified"))
 		return
 	}
-	if !roi.IsValidShot(shot) {
-		apiBadRequest(w, fmt.Errorf("shot id '%s' is not valid", shot))
-		return
-	}
 	_, err = roi.GetShot(DB, show+"/"+shot)
 	if err == nil {
 		apiBadRequest(w, fmt.Errorf("shot already exist: %v", shot))

--- a/cmd/roi/shot_handler.go
+++ b/cmd/roi/shot_handler.go
@@ -106,10 +106,6 @@ func updateShotHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		return err
 	}
 	id := r.FormValue("id")
-	err = roi.VerifyShotID(id)
-	if err != nil {
-		return err
-	}
 	s, err := roi.GetShot(DB, id)
 	if err != nil {
 		return err
@@ -214,12 +210,6 @@ func updateMultiShotsHandler(w http.ResponseWriter, r *http.Request, env *Env) e
 		return err
 	}
 	ids := r.Form["id"]
-	for _, id := range ids {
-		err = roi.VerifyShotID(id)
-		if err != nil {
-			return err
-		}
-	}
 	id := ids[0]
 	show, _, err := roi.SplitShotID(id)
 	if err != nil {

--- a/cmd/roi/shot_main.go
+++ b/cmd/roi/shot_main.go
@@ -56,10 +56,6 @@ ex) localhost
 		fname := filepath.Base(f)
 		show = strings.TrimSuffix(fname, filepath.Ext(fname))
 	}
-	if !roi.IsValidShow(show) {
-		fmt.Fprintln(os.Stderr, show, "이 프로젝트 아이디로 적절치 않습니다.")
-		os.Exit(1)
-	}
 
 	xl, err := excelize.OpenFile(f)
 	if err != nil {

--- a/cmd/roi/task_handler.go
+++ b/cmd/roi/task_handler.go
@@ -17,10 +17,6 @@ func updateTaskHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		return err
 	}
 	id := r.FormValue("id")
-	err = roi.VerifyTaskID(id)
-	if err != nil {
-		return err
-	}
 	t, err := roi.GetTask(DB, id)
 	if err != nil {
 		return err
@@ -55,10 +51,6 @@ func updateTaskPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 		return err
 	}
 	id := r.FormValue("id")
-	err = roi.VerifyTaskID(id)
-	if err != nil {
-		return err
-	}
 	tforms, err := parseTimeForms(r.Form, "due_date")
 	if err != nil {
 		return err
@@ -97,10 +89,6 @@ func updateTaskWorkingVersionHandler(w http.ResponseWriter, r *http.Request, env
 		return err
 	}
 	id := r.FormValue("id")
-	err = roi.VerifyTaskID(id)
-	if err != nil {
-		return err
-	}
 	version := r.FormValue("version")
 	err = roi.UpdateTaskWorkingVersion(DB, id, version)
 	if err != nil {
@@ -121,10 +109,6 @@ func updateTaskPublishVersionHandler(w http.ResponseWriter, r *http.Request, env
 		return err
 	}
 	id := r.FormValue("id")
-	err = roi.VerifyTaskID(id)
-	if err != nil {
-		return err
-	}
 	version := r.FormValue("version")
 	err = roi.UpdateTaskPublishVersion(DB, id, version)
 	if err != nil {
@@ -147,12 +131,6 @@ func updateMultiTasksHandler(w http.ResponseWriter, r *http.Request, env *Env) e
 		return err
 	}
 	ids := r.Form["id"]
-	for _, id := range ids {
-		err = roi.VerifyShotID(id)
-		if err != nil {
-			return err
-		}
-	}
 	id := ids[0]
 	show, _, err := roi.SplitShotID(id)
 	if err != nil {

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -73,10 +73,6 @@ func updateVersionHandler(w http.ResponseWriter, r *http.Request, env *Env) erro
 		return err
 	}
 	id := r.FormValue("id")
-	err = roi.VerifyVersionID(id)
-	if err != nil {
-		return err
-	}
 	v, err := roi.GetVersion(DB, id)
 	if err != nil {
 		return err
@@ -107,10 +103,6 @@ func updateVersionPostHandler(w http.ResponseWriter, r *http.Request, env *Env) 
 		return err
 	}
 	id := r.FormValue("id")
-	err = roi.VerifyVersionID(id)
-	if err != nil {
-		return err
-	}
 	timeForms, err := parseTimeForms(r.Form, "start_date", "end_date")
 	if err != nil {
 		return err
@@ -147,10 +139,6 @@ func updateVersionStatusHandler(w http.ResponseWriter, r *http.Request, env *Env
 		return err
 	}
 	id := r.FormValue("id")
-	err = roi.VerifyVersionID(id)
-	if err != nil {
-		return err
-	}
 	status := roi.VersionStatus(r.FormValue("update-status"))
 	err = roi.UpdateVersionStatus(DB, id, status)
 	if err != nil {

--- a/shot.go
+++ b/shot.go
@@ -87,9 +87,20 @@ func SplitShotID(id string) (string, string, error) {
 	return show, shot, nil
 }
 
-// VerifyShotID는 받아들인 샷 아이디가 유효하지 않다면 에러를 반환한다.
-func VerifyShotID(id string) error {
-	_, _, err := SplitShotID(id)
+// verifyShotID는 받아들인 샷 아이디가 유효하지 않다면 에러를 반환한다.
+func verifyShotID(id string) error {
+	show, shot, err := SplitShotID(id)
+	if err != nil {
+		return err
+	}
+	err = verifyShowName(show)
+	if err != nil {
+		return err
+	}
+	err = verifyShotName(shot)
+	if err != nil {
+		return err
+	}
 	return err
 }
 
@@ -111,7 +122,7 @@ func VerifyShotID(id string) error {
 // 마지막 샷 이름의 경우 기본 이름은 CG_0010, 접미어는 CG가 된다.
 
 var (
-	// reShotName은 샷 이름을 나타내는 정규식이다.
+	// reShotName은 유효한 샷 이름을 나타내는 정규식이다.
 	reShotName = regexp.MustCompile(`^[a-zA-Z]+[_]?[0-9]+[_]?[a-zA-Z]*$`)
 	// reShotBase는 샷 이름에서 접미어가 빠진 이름을 나타내는 정규식이다.
 	reShotBase = regexp.MustCompile(`^[a-zA-Z]+[_]?[0-9]+`)
@@ -119,9 +130,13 @@ var (
 	reShotPrefix = regexp.MustCompile(`^[a-zA-Z]+`)
 )
 
-// IsValidShot은 해당 이름이 샷 이름으로 적절한지 여부를 반환한다.
-func IsValidShot(shot string) bool {
-	return reShotName.MatchString(shot)
+// verifyShotName은 해당 이름이 샷 이름으로 적절한지 검사하고 적절하지 않다면
+// 에러를 반환한다.
+func verifyShotName(shot string) error {
+	if !reShotName.MatchString(shot) {
+		return fmt.Errorf("invalid shot name: %s", shot)
+	}
+	return nil
 }
 
 // ShotBase는 샷 이름에서 접미어를 제외한 기본 이름 정보를 반환한다.
@@ -135,20 +150,32 @@ func ShotPrefix(shot string) string {
 	return reShotPrefix.FindString(shot)
 }
 
+// verifyShot은 받아들인 샷이 유효하지 않다면 에러를 반환한다.
+func verifyShot(s *Shot) error {
+	if s == nil {
+		return fmt.Errorf("nil shot")
+	}
+	err := verifyShotID(s.ID())
+	if err != nil {
+		return err
+	}
+	err = verifyShotStatus(s.Status)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // AddShot은 db의 특정 프로젝트에 샷을 하나 추가한다.
 func AddShot(db *sql.DB, s *Shot) error {
-	if s == nil {
-		return BadRequest("nil shot is invalid")
-	}
-	if !IsValidShot(s.Shot) {
-		return BadRequest(fmt.Sprintf("invalid shot id: '%s'", s.Shot))
+	err := verifyShot(s)
+	if err != nil {
+		return err
 	}
 	s.Name = ShotBase(s.Shot)
 	s.Prefix = ShotPrefix(s.Shot)
-	if !isValidShotStatus(s.Status) {
-		return BadRequest(fmt.Sprintf("invalid shot status: '%s'", s.Status))
-	}
-	_, err := GetShow(db, s.Show)
+	// 부모가 있는지 검사
+	_, err = GetShow(db, s.Show)
 	if err != nil {
 		return err
 	}
@@ -309,23 +336,23 @@ func SearchShots(db *sql.DB, show string, shots []string, tag, status, task, ass
 // UpdateShot은 db에서 해당 샷을 수정한다.
 // 이 함수를 호출하기 전 해당 샷이 존재하는지 사용자가 검사해야 한다.
 func UpdateShot(db *sql.DB, id string, s *Shot) error {
-	if s == nil {
-		return fmt.Errorf("nil shot")
-	}
-	show, shot, err := SplitShotID(id)
+	err := verifyShotID(id)
 	if err != nil {
 		return err
 	}
-	if !isValidShotStatus(s.Status) {
-		return BadRequest(fmt.Sprintf("invalid shot status: '%s'", s.Status))
+	err = verifyShot(s)
+	if err != nil {
+		return err
 	}
+	s.Name = ShotBase(s.Shot)
+	s.Prefix = ShotPrefix(s.Shot)
 	ks, is, vs, err := dbKIVs(s)
 	if err != nil {
 		return err
 	}
 	keys := strings.Join(ks, ", ")
 	idxs := strings.Join(is, ", ")
-	stmt := fmt.Sprintf("UPDATE shots SET (%s) = (%s) WHERE show='%s' AND shot='%s'", keys, idxs, show, shot)
+	stmt := fmt.Sprintf("UPDATE shots SET (%s) = (%s) WHERE show='%s' AND shot='%s'", keys, idxs, s.Show, s.Shot)
 	if _, err := db.Exec(stmt, vs...); err != nil {
 		return err
 	}

--- a/shot.go
+++ b/shot.go
@@ -130,8 +130,7 @@ var (
 	reShotPrefix = regexp.MustCompile(`^[a-zA-Z]+`)
 )
 
-// verifyShotName은 해당 이름이 샷 이름으로 적절한지 검사하고 적절하지 않다면
-// 에러를 반환한다.
+// verifyShotName은 받아들인 샷 이름이 유효하지 않다면 에러를 반환한다.
 func verifyShotName(shot string) error {
 	if !reShotName.MatchString(shot) {
 		return fmt.Errorf("invalid shot name: %s", shot)

--- a/shot_status.go
+++ b/shot_status.go
@@ -1,5 +1,7 @@
 package roi
 
+import "fmt"
+
 type ShotStatus string
 
 const (
@@ -18,14 +20,14 @@ var AllShotStatus = []ShotStatus{
 	ShotOmit,
 }
 
-// isValidShotStatus는 해당 샷 상태가 유효한지를 반환한다.
-func isValidShotStatus(ss ShotStatus) bool {
+// verifyShotStatus는 받아들인 샷의 상태가 유효하지 않다면 에러를 반환한다.
+func verifyShotStatus(ss ShotStatus) error {
 	for _, s := range AllShotStatus {
 		if ss == s {
-			return true
+			return nil
 		}
 	}
-	return false
+	return BadRequest(fmt.Sprintf("invalid shot status: '%s'", ss))
 }
 
 func (s ShotStatus) UIString() string {

--- a/shot_test.go
+++ b/shot_test.go
@@ -70,10 +70,9 @@ func TestShot(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not get shot from shots table: %s", err)
 		}
-		if !IsValidShot(got.Shot) {
-			if err != nil {
-				t.Fatalf("find shot with invalid id from shots table: %s", err)
-			}
+		err = verifyShotName(got.Shot)
+		if err != nil {
+			t.Fatalf("find shot with invalid id from shots table: %s", err)
 		}
 		if !reflect.DeepEqual(got, s) {
 			t.Fatalf("got: %v, want: %v", got, s)

--- a/show.go
+++ b/show.go
@@ -62,12 +62,12 @@ func (s *Show) ID() string {
 	return s.Show
 }
 
-// reValidShow는 유효한 쇼 이름을 정의하는 정규식이다.
-var reValidShow = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+// reShowName는 유효한 쇼 이름을 정의하는 정규식이다.
+var reShowName = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 
 // verifyShowName은 받아들인 쇼 이름이 유효하지 않다면 에러를 반환한다.
 func verifyShowName(name string) error {
-	if !reValidShow.MatchString(name) {
+	if !reShowName.MatchString(name) {
 		return BadRequest(fmt.Sprintf("invalid show name: %s", name))
 	}
 	return nil

--- a/show_status.go
+++ b/show_status.go
@@ -1,5 +1,7 @@
 package roi
 
+import "fmt"
+
 type ShowStatus string
 
 const (
@@ -20,14 +22,14 @@ var AllShowStatus = []ShowStatus{
 	ShowHold,
 }
 
-// isValidShowStatus는 해당 태스크 상태가 유효한지를 반환한다.
-func isValidShowStatus(ss ShowStatus) bool {
+// verifyShowStatus는 해당 태스크 상태가 유효하지 않다면 에러를 반환한다.
+func verifyShowStatus(ss ShowStatus) error {
 	for _, s := range AllShowStatus {
 		if ss == s {
-			return true
+			return nil
 		}
 	}
-	return false
+	return BadRequest(fmt.Sprintf("invalid show status: '%s'", ss))
 }
 
 // UIString은 UI안에서 사용하는 현지화된 문자열이다.

--- a/task.go
+++ b/task.go
@@ -61,8 +61,7 @@ func (t *Task) ShotID() string {
 // 태스크명은 언더바를 이용해 서브 태스크를 나타낼 수 있다.
 var reTaskName = regexp.MustCompile(`^[a-zA-Z0-9]+(_[a-zA-Z0-9]+)?$`)
 
-// verifyTaskName은 해당 이름이 샷 이름으로 적절한지 검사하고 적절하지 않다면
-// 에러를 반환한다.
+// verifyTaskName은 받아들인 샷 이름이 유효하지 않다면 에러를 반환한다.
 func verifyTaskName(task string) error {
 	if !reTaskName.MatchString(task) {
 		return fmt.Errorf("invalid task name: %s", task)

--- a/task_status.go
+++ b/task_status.go
@@ -1,5 +1,7 @@
 package roi
 
+import "fmt"
+
 type TaskStatus string
 
 const (
@@ -14,14 +16,14 @@ var AllTaskStatus = []TaskStatus{
 	TaskDone,
 }
 
-// isValidTaskStatus는 해당 태스크 상태가 유효한지를 반환한다.
-func isValidTaskStatus(ts TaskStatus) bool {
+// verifyTaskStatus는 받아들인 태스크 상태가 유효하지 않다면 에러를 반환한다.
+func verifyTaskStatus(ts TaskStatus) error {
 	for _, s := range AllTaskStatus {
 		if ts == s {
-			return true
+			return nil
 		}
 	}
-	return false
+	return BadRequest(fmt.Sprintf("invalid task status: '%s'", ts))
 }
 
 // UIString은 UI안에서 사용하는 현지화된 문자열이다.

--- a/task_test.go
+++ b/task_test.go
@@ -29,7 +29,14 @@ func TestTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not add task: %s", err)
 	}
-	tasks, err := UserTasks(db, "kybin")
+	tasks, err := ShotTasks(db, testShotA.ID())
+	if err != nil {
+		t.Fatalf("could not get shot tasks: %s", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("invalid number of shot tasks: want 1, got %d", len(tasks))
+	}
+	tasks, err = UserTasks(db, "kybin")
 	if err != nil {
 		t.Fatalf("could not get user tasks: %s", err)
 	}

--- a/version.go
+++ b/version.go
@@ -64,8 +64,7 @@ func (v *Version) TaskID() string {
 // reVersionName은 가능한 버전명을 정의하는 정규식이다.
 var reVersionName = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 
-// verifyVersionName은 해당 이름이 버전 이름으로 적절한지 검사하고 적절하지 않다면
-// 에러를 반환한다.
+// verifyVersionName은 받아들인 버전 이름이 유효하지 않다면 에러를 반환한다.
 func verifyVersionName(version string) error {
 	if !reVersionName.MatchString(version) {
 		return fmt.Errorf("invalid version name: %s", version)

--- a/version_status.go
+++ b/version_status.go
@@ -1,5 +1,7 @@
 package roi
 
+import "fmt"
+
 type VersionStatus string
 
 const (
@@ -18,14 +20,14 @@ var AllVersionStatus = []VersionStatus{
 	VersionApproved,
 }
 
-// isValidVersionStatus는 해당 태스크 상태가 유효한지를 반환한다.
-func isValidVersionStatus(ts VersionStatus) bool {
+// verifyVersionStatus는 받아들인 버전 상태가 유효하지 않다면 에러를 반환한다.
+func verifyVersionStatus(vs VersionStatus) error {
 	for _, s := range AllVersionStatus {
-		if ts == s {
-			return true
+		if vs == s {
+			return nil
 		}
 	}
-	return false
+	return BadRequest(fmt.Sprintf("invalid version status: %s", vs))
 }
 
 // UIString은 UI안에서 사용하는 현지화된 문자열이다.

--- a/version_test.go
+++ b/version_test.go
@@ -12,6 +12,7 @@ var testVersionA = &Version{
 	Task:    testTaskA.Task,
 	Version: "v001",
 
+	Status:      VersionInProgress,
 	Owner:       "admin",
 	OutputFiles: []string{"/project/test/FOO_0010/scene/test.v001.abc"},
 	Images: []string{


### PR DESCRIPTION
지금까지는 cmd/roi의 핸들러 함수등에서 항목 추가, 업데이트 전
미리 검사하던 것을 roi 패키지 쪽으로 옮기고 roi.Add{...},
roi.Update{...} 함수 실행시 새로 생성한 verify 함수를 이용해
검사하는 방향으로 변경하였음.

 Close: #289