### PR TITLE
쇼 설정 페이지의 날짜 필드가 업데이트 되지 않던 것 수정

### DIFF
--- a/cmd/roi/tmpl/update-show.html
+++ b/cmd/roi/tmpl/update-show.html
@@ -53,19 +53,19 @@
 			<input type="text" name="cg_supervisor" value="{{.Show.CGSupervisor}}"/>
 		</div>
 		<div class="field"><label>크랭크 인</label>
-			<input type="date" name="crank_in" value="{{stringFromTime .Show.CrankIn}}"/>
+			<input type="date" name="crank_in" value="{{stringFromDate .Show.CrankIn}}"/>
 		</div>
 		<div class="field"><label>크랭크 업</label>
-			<input type="date" name="crank_up" value="{{stringFromTime .Show.CrankUp}}"/>
+			<input type="date" name="crank_up" value="{{stringFromDate .Show.CrankUp}}"/>
 		</div>
 		<div class="field"><label>시작일</label>
-			<input type="date" name="start_date" value="{{stringFromTime .Show.StartDate}}"/>
+			<input type="date" name="start_date" value="{{stringFromDate .Show.StartDate}}"/>
 		</div>
 		<div class="field"><label>종료일</label>
-			<input type="date" name="release_date" value="{{stringFromTime .Show.ReleaseDate}}"/>
+			<input type="date" name="release_date" value="{{stringFromDate .Show.ReleaseDate}}"/>
 		</div>
 		<div class="field"><label>VFX 종료일</label>
-			<input type="date" name="vfx_due_date" value="{{stringFromTime .Show.VFXDueDate}}"/>
+			<input type="date" name="vfx_due_date" value="{{stringFromDate .Show.VFXDueDate}}"/>
 		</div>
 		<div class="field"><label>아웃풋 사이즈</label>
 			<input type="text" name="output_size" value="{{.Show.OutputSize}}"/>


### PR DESCRIPTION
go의 time.Time을 html의 date타입 인풋 문자열로 변경할 때
날짜보다 하위인 시분초 문자열까지 입력이 되어 에러가 났었음.

Close: #417