### PR TITLE
ROI_DB_ADDR 환경변수를 인식하도록 함

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,12 @@ mkcert -cert-file=cert.pem -key-file=key.pem localhost
 cd ~/roi/cmd/roi
 sudo ./roi server
 ```
+
+### 환경변수
+
+로이가 사용하는 환경변수는 다음과 같습니다.
+
+```
+ROI_ADDR: -addr 플래그를 지정하지 않았을때 서버가 바인딩하고, 클라이언트가 접근하는 주소입니다.
+ROI_DB_ADDR: -db-addr 플래그를 지정하지 않았을때 서버가 사용하는 DB 주소입니다.
+```

--- a/cmd/roi/server_main.go
+++ b/cmd/roi/server_main.go
@@ -74,7 +74,18 @@ when ROI_ADDR environment variable is not empty, it will use the value as defaul
 	serverFlag.BoolVar(&insecure, "insecure", false, "use insecure http protocol instead of https.")
 	serverFlag.StringVar(&cert, "cert", "cert/cert.pem", "https cert file. need to use https protocol.")
 	serverFlag.StringVar(&key, "key", "cert/key.pem", "https key file. need to use https protocol.")
-	serverFlag.StringVar(&dbAddr, "db-addr", "localhost:26257", "host url and port of database.")
+	dbAddrHelp := `host url and port of database.
+
+when ROI_DB_ADDR environment variable is not empty, it will use the value as default.
+
+`
+	dbAddrDefault := "localhost:26257"
+	dbAddrEnv := os.Getenv("ROI_DB_ADDR")
+	if dbAddrEnv != "" {
+		dbAddrDefault = dbAddrEnv
+		dbAddrHelp += "currently the default value is comming from ROI_DB_ADDR"
+	}
+	serverFlag.StringVar(&dbAddr, "db-addr", dbAddrDefault, dbAddrHelp)
 	serverFlag.StringVar(&dbCA, "db-ca", "db-cert/ca.crt", "root certificate authority file of the database.")
 	serverFlag.StringVar(&dbCert, "db-cert", "db-cert/client.root.crt", "client certificate file of database.")
 	serverFlag.StringVar(&dbKey, "db-key", "db-cert/client.root.key", "client key file of database.")

--- a/cmd/roi/start-db.sh
+++ b/cmd/roi/start-db.sh
@@ -3,4 +3,8 @@ set -e
 
 CERT_DIR=$(dirname $BASH_SOURCE)/db-cert
 
-cockroach start-single-node --certs-dir=$CERT_DIR --listen-addr=localhost:26257
+ADDR=localhost:26257
+if [ ! -z $ROI_DB_ADDR ]; then
+	ADDR=$ROI_DB_ADDR
+fi
+cockroach start-single-node --certs-dir=$CERT_DIR --listen-addr=$ADDR


### PR DESCRIPTION
start-db.sh도 그에 맞추어 지정된 포트에 바인딩 되도록 하였음.

Close: #476