### PR TITLE
ROI_DB_HTTP_ADDR 환경변수 사용

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,5 @@ sudo ./roi server
 ```
 ROI_ADDR: -addr 플래그를 지정하지 않았을때 서버가 바인딩하고, 클라이언트가 접근하는 주소입니다.
 ROI_DB_ADDR: -db-addr 플래그를 지정하지 않았을때 서버가 사용하는 DB 주소입니다.
+ROI_DB_HTTP_ADDR: start-db.sh가 사용하는 DB의 웹 서비스 주소입니다.
 ```

--- a/cmd/roi/start-db.sh
+++ b/cmd/roi/start-db.sh
@@ -7,4 +7,10 @@ ADDR=localhost:26257
 if [ ! -z $ROI_DB_ADDR ]; then
 	ADDR=$ROI_DB_ADDR
 fi
-cockroach start-single-node --certs-dir=$CERT_DIR --listen-addr=$ADDR
+
+HTTP_ADDR=localhost:8080
+if [ ! -z $ROI_DB_HTTP_ADDR ]; then
+	HTTP_ADDR=$ROI_DB_HTTP_ADDR
+fi
+
+cockroach start-single-node --certs-dir=$CERT_DIR --http-addr=$HTTP_ADDR --listen-addr=$ADDR


### PR DESCRIPTION
여러 cockroach db가 충돌을 피하려면 listen-addr 뿐 아니라
http-addr도 달라야 한다.