### PR TITLE
태스크가 하나의 리뷰대기 버전만 가지도록 함

### DIFF
--- a/cmd/roi/task_handler.go
+++ b/cmd/roi/task_handler.go
@@ -71,7 +71,7 @@ func updateTaskPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 	t.DueDate = tforms["due_date"]
 	t.PublishVersion = r.FormValue("publish_version")
 	t.ApprovedVersion = r.FormValue("approved_version")
-	t.ReviewVersions = fieldSplit(r.FormValue("review_versions"))
+	t.ReviewVersion = r.FormValue("review_version")
 	t.WorkingVersion = r.FormValue("working_version")
 
 	err = roi.UpdateTask(DB, id, t)

--- a/cmd/roi/tmpl/update-task.bml
+++ b/cmd/roi/tmpl/update-task.bml
@@ -34,7 +34,7 @@
 			<input type="text" name="approved_version" value="{{$t.ApprovedVersion}}">
 		]
 		<div class="field"> [<label> [리뷰가 필요한 버전]
-			<input type="text" name="review_versions" placeholder="version, version" value="{{fieldJoin $t.ReviewVersions}}">
+			<input type="text" name="review_version" value="{{$t.ReviewVersion}}">
 		]
 		<div class="field"> [<label> [진행중인 버전]
 			<input type="text" name="working_version" value="{{$t.WorkingVersion}}">


### PR DESCRIPTION
진행, 리뷰대기, 승인, 퍼블리시를 모두 하나만
쓰는 것이 더 단순해서 좋아 보인다.