### PR TITLE
roi의 주요 함수들이 아이디 대신 각 항목의 이름을 받도록 함

### DIFF
--- a/category.go
+++ b/category.go
@@ -12,3 +12,15 @@ func verifyCategoryName(ctg string) error {
 	}
 	return fmt.Errorf("invalid category: %s", ctg)
 }
+
+func verifyCategoryPrimaryKeys(show, ctg string) error {
+	err := verifyShowName(show)
+	if err != nil {
+		return err
+	}
+	err = verifyCategoryName(ctg)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/roi/api.go
+++ b/cmd/roi/api.go
@@ -91,7 +91,7 @@ func addUnitApiHandler(w http.ResponseWriter, r *http.Request) {
 		apiBadRequest(w, fmt.Errorf("invalid unit id: %v", id))
 		return
 	}
-	_, err = roi.GetUnit(DB, id)
+	_, err = roi.GetUnit(DB, show, ctg, grp, unit)
 	if err == nil {
 		apiBadRequest(w, fmt.Errorf("unit already exist: %v", id))
 		return
@@ -184,7 +184,12 @@ func getUnitApiHandler(w http.ResponseWriter, r *http.Request) {
 	ids := r.Form["id"]
 	ss := make(map[string]*roi.Unit)
 	for _, id := range ids {
-		s, err := roi.GetUnit(DB, id)
+		show, ctg, grp, unit, err := roi.SplitUnitID(id)
+		if err != nil {
+			apiBadRequest(w, fmt.Errorf("invalid unit id: %v", id))
+			return
+		}
+		s, err := roi.GetUnit(DB, show, ctg, grp, unit)
 		if err != nil {
 			apiBadRequest(w, err)
 			return
@@ -208,7 +213,12 @@ func getUnitTasksApiHandler(w http.ResponseWriter, r *http.Request) {
 	ids := r.Form["id"]
 	allTs := make(map[string][]*roi.Task)
 	for _, id := range ids {
-		ts, err := roi.UnitTasks(DB, id)
+		show, ctg, grp, unit, err := roi.SplitUnitID(id)
+		if err != nil {
+			apiBadRequest(w, fmt.Errorf("invalid unit id: %v", id))
+			return
+		}
+		ts, err := roi.UnitTasks(DB, show, ctg, grp, unit)
 		if err != nil {
 			apiBadRequest(w, err)
 			return

--- a/cmd/roi/group_handler.go
+++ b/cmd/roi/group_handler.go
@@ -59,10 +59,9 @@ func addGroupPostHandler(w http.ResponseWriter, r *http.Request, env *Env) error
 	show := r.FormValue("show")
 	ctg := r.FormValue("category")
 	grp := r.FormValue("group")
-	id := show + "/" + ctg + "/" + grp
-	_, err = roi.GetGroup(DB, id)
+	_, err = roi.GetGroup(DB, show, ctg, grp)
 	if err == nil {
-		return roi.BadRequest(fmt.Sprintf("group already exist: %s", id))
+		return roi.BadRequest(fmt.Sprintf("group already exist: %s", roi.JoinGroupID(show, ctg, grp)))
 	} else if !errors.As(err, &roi.NotFoundError{}) {
 		return err
 	}
@@ -75,7 +74,7 @@ func addGroupPostHandler(w http.ResponseWriter, r *http.Request, env *Env) error
 	if err != nil {
 		return err
 	}
-	http.Redirect(w, r, "/update-group?id="+id, http.StatusSeeOther)
+	http.Redirect(w, r, "/update-group?id="+roi.JoinGroupID(show, ctg, grp), http.StatusSeeOther)
 	return nil
 }
 
@@ -90,7 +89,11 @@ func updateGroupHandler(w http.ResponseWriter, r *http.Request, env *Env) error 
 		return err
 	}
 	id := r.FormValue("id")
-	p, err := roi.GetGroup(DB, id)
+	show, ctg, grp, err := roi.SplitGroupID(id)
+	if err != nil {
+		return err
+	}
+	p, err := roi.GetGroup(DB, show, ctg, grp)
 	if err != nil {
 		return err
 	}
@@ -110,7 +113,11 @@ func updateGroupPostHandler(w http.ResponseWriter, r *http.Request, env *Env) er
 		return err
 	}
 	id := r.FormValue("id")
-	s, err := roi.GetGroup(DB, id)
+	show, ctg, grp, err := roi.SplitGroupID(id)
+	if err != nil {
+		return err
+	}
+	s, err := roi.GetGroup(DB, show, ctg, grp)
 	if err != nil {
 		return err
 	}
@@ -130,7 +137,7 @@ func updateGroupPostHandler(w http.ResponseWriter, r *http.Request, env *Env) er
 		s.Attrs[k] = v
 	}
 
-	err = roi.UpdateGroup(DB, id, s)
+	err = roi.UpdateGroup(DB, show, ctg, grp, s)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/units_handler.go
+++ b/cmd/roi/units_handler.go
@@ -106,7 +106,7 @@ func unitsHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 	}
 	tasks := make(map[string]map[string]*roi.Task)
 	for _, s := range ss {
-		ts, err := roi.UnitTasks(DB, s.ID())
+		ts, err := roi.UnitTasks(DB, s.Show, s.Category, s.Group, s.Unit)
 		if err != nil {
 			return err
 		}

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -76,11 +76,15 @@ func updateVersionHandler(w http.ResponseWriter, r *http.Request, env *Env) erro
 		return err
 	}
 	id := r.FormValue("id")
-	v, err := roi.GetVersion(DB, id)
+	show, ctg, grp, unit, task, ver, err := roi.SplitVersionID(id)
 	if err != nil {
 		return err
 	}
-	t, err := roi.GetTask(DB, v.TaskID())
+	v, err := roi.GetVersion(DB, show, ctg, grp, unit, task, ver)
+	if err != nil {
+		return err
+	}
+	t, err := roi.GetTask(DB, show, ctg, grp, unit, task)
 	if err != nil {
 		return err
 	}
@@ -104,6 +108,10 @@ func updateVersionPostHandler(w http.ResponseWriter, r *http.Request, env *Env) 
 		return err
 	}
 	id := r.FormValue("id")
+	show, ctg, grp, unit, task, ver, err := roi.SplitVersionID(id)
+	if err != nil {
+		return err
+	}
 	timeForms, err := parseTimeForms(r.Form, "start_date", "end_date")
 	if err != nil {
 		return err
@@ -113,7 +121,7 @@ func updateVersionPostHandler(w http.ResponseWriter, r *http.Request, env *Env) 
 	if err != nil {
 		return err
 	}
-	v, err := roi.GetVersion(DB, id)
+	v, err := roi.GetVersion(DB, show, ctg, grp, unit, task, ver)
 	if err != nil {
 		return err
 	}
@@ -123,7 +131,7 @@ func updateVersionPostHandler(w http.ResponseWriter, r *http.Request, env *Env) 
 	v.StartDate = timeForms["start_date"]
 	v.EndDate = timeForms["end_date"]
 
-	err = roi.UpdateVersion(DB, id, v)
+	err = roi.UpdateVersion(DB, show, ctg, grp, unit, task, ver, v)
 	if err != nil {
 		return err
 	}

--- a/group.go
+++ b/group.go
@@ -56,13 +56,12 @@ func SplitGroupID(id string) (string, string, string, error) {
 	return show, ctg, group, nil
 }
 
-// verifyGroupID는 받아들인 샷 아이디가 유효하지 않다면 에러를 반환한다.
-func verifyGroupID(id string) error {
-	show, ctg, group, err := SplitGroupID(id)
-	if err != nil {
-		return err
-	}
-	err = verifyShowName(show)
+func JoinGroupID(show, ctg, grp string) string {
+	return show + "/" + ctg + "/" + grp
+}
+
+func verifyGroupPrimaryKeys(show, ctg, grp string) error {
+	err := verifyShowName(show)
 	if err != nil {
 		return err
 	}
@@ -70,29 +69,12 @@ func verifyGroupID(id string) error {
 	if err != nil {
 		return err
 	}
-	err = verifyGroupName(group)
+	err = verifyGroupName(grp)
 	if err != nil {
 		return err
 	}
-	return err
+	return nil
 }
-
-// 샷 이름은 일반적으로 (시퀀스를 나타내는) 접두어, 샷 번호, 접미어로 나뉜다.
-// 접두어와 샷 번호는 항상 필요하지만, 접미어는 없어도 된다.
-//
-// CG0010a에서 접두어는 CG, 샷 번호는 0010, 접미어는 a이다.
-//
-// 접두어와 샷번호, 접미어를 언더바(_)를 통해서 떨어뜨리거나, 그냥 붙여쓰는것이 가능하다.
-//
-// 아래는 모두 유효한 샷 이름이다.
-//
-// CG0010
-// CG0010a
-// CG0010_a
-// CG_0010a
-// CG_0010_a
-//
-// 마지막 샷 이름의 경우 기본 이름은 CG_0010, 접미어는 CG가 된다.
 
 var (
 	// reGroupName은 유효한 샷 이름을 나타내는 정규식이다.
@@ -113,7 +95,7 @@ func verifyGroup(db *sql.DB, s *Group) error {
 	if s == nil {
 		return fmt.Errorf("nil group")
 	}
-	return verifyGroupID(s.ID())
+	return verifyGroupPrimaryKeys(s.Show, s.Category, s.Group)
 }
 
 // AddGroup은 db의 특정 프로젝트에 샷을 하나 추가한다.
@@ -135,8 +117,8 @@ func AddGroup(db *sql.DB, s *Group) error {
 
 // GetGroup은 db에서 하나의 샷을 찾는다.
 // 해당 샷이 존재하지 않는다면 nil과 NotFound 에러를 반환한다.
-func GetGroup(db *sql.DB, id string) (*Group, error) {
-	show, ctg, group, err := SplitGroupID(id)
+func GetGroup(db *sql.DB, show, ctg, grp string) (*Group, error) {
+	err := verifyGroupPrimaryKeys(show, ctg, grp)
 	if err != nil {
 		return nil, err
 	}
@@ -145,13 +127,13 @@ func GetGroup(db *sql.DB, id string) (*Group, error) {
 		return nil, err
 	}
 	s := &Group{}
-	stmt := dbStmt(fmt.Sprintf("SELECT %s FROM groups WHERE show=$1 AND category=$2 AND grp=$3 LIMIT 1", groupDBKey), show, ctg, group)
+	stmt := dbStmt(fmt.Sprintf("SELECT %s FROM groups WHERE show=$1 AND category=$2 AND grp=$3 LIMIT 1", groupDBKey), show, ctg, grp)
 	err = dbQueryRow(db, stmt, func(row *sql.Row) error {
 		return scan(row, s)
 	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, NotFound("group", id)
+			return nil, NotFound("group", JoinGroupID(show, ctg, grp))
 		}
 		return nil, err
 	}
@@ -159,9 +141,13 @@ func GetGroup(db *sql.DB, id string) (*Group, error) {
 }
 
 func Groups(db *sql.DB, show, ctg string) ([]*Group, error) {
+	err := verifyCategoryPrimaryKeys(show, ctg)
+	if err != nil {
+		return nil, err
+	}
 	grps := make([]*Group, 0)
 	stmt := dbStmt(fmt.Sprintf("SELECT %s FROM groups WHERE show=$1 AND category=$2", groupDBKey), show, ctg)
-	err := dbQuery(db, stmt, func(row *sql.Rows) error {
+	err = dbQuery(db, stmt, func(row *sql.Rows) error {
 		g := &Group{}
 		err := scan(row, g)
 		if err != nil {
@@ -178,8 +164,8 @@ func Groups(db *sql.DB, show, ctg string) ([]*Group, error) {
 
 // UpdateGroup은 db에서 해당 샷을 수정한다.
 // 이 함수를 호출하기 전 해당 샷이 존재하는지 사용자가 검사해야 한다.
-func UpdateGroup(db *sql.DB, id string, s *Group) error {
-	err := verifyGroupID(id)
+func UpdateGroup(db *sql.DB, show, ctg, grp string, s *Group) error {
+	err := verifyGroupPrimaryKeys(show, ctg, grp)
 	if err != nil {
 		return err
 	}
@@ -193,23 +179,18 @@ func UpdateGroup(db *sql.DB, id string, s *Group) error {
 	return dbExec(db, stmts)
 }
 
-// DeleteGroup은 해당 샷과 그 하위의 모든 데이터를 db에서 지운다.
-// 해당 샷이 없어도 에러를 내지 않기 때문에 검사를 원한다면 GroupExist를 사용해야 한다.
+// DeleteGroup은 해당 그룹과 그 하위의 모든 데이터를 db에서 지운다.
 // 만일 처리 중간에 에러가 나면 아무 데이터도 지우지 않고 에러를 반환한다.
-func DeleteGroup(db *sql.DB, id string) error {
-	show, ctg, group, err := SplitGroupID(id)
-	if err != nil {
-		return err
-	}
-	_, err = GetGroup(db, id)
+func DeleteGroup(db *sql.DB, show, ctg, grp string) error {
+	_, err := GetGroup(db, show, ctg, grp)
 	if err != nil {
 		return err
 	}
 	stmts := []dbStatement{
-		dbStmt("DELETE FROM groups WHERE show=$1 AND category=$2 AND grp=$3", show, ctg, group),
-		dbStmt("DELETE FROM units WHERE show=$1 AND category=$2 AND grp=$3", show, ctg, group),
-		dbStmt("DELETE FROM tasks WHERE show=$1 AND category=$2 AND grp=$3", show, ctg, group),
-		dbStmt("DELETE FROM versions WHERE show=$1 AND category=$2 AND grp=$3", show, ctg, group),
+		dbStmt("DELETE FROM groups WHERE show=$1 AND category=$2 AND grp=$3", show, ctg, grp),
+		dbStmt("DELETE FROM units WHERE show=$1 AND category=$2 AND grp=$3", show, ctg, grp),
+		dbStmt("DELETE FROM tasks WHERE show=$1 AND category=$2 AND grp=$3", show, ctg, grp),
+		dbStmt("DELETE FROM versions WHERE show=$1 AND category=$2 AND grp=$3", show, ctg, grp),
 	}
 	return dbExec(db, stmts)
 }

--- a/group_test.go
+++ b/group_test.go
@@ -46,18 +46,18 @@ func TestGroup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not add group to groups table: %s", err)
 	}
-	got, err := GetGroup(db, s.ID())
+	got, err := GetGroup(db, s.Show, s.Category, s.Group)
 	if err != nil {
 		t.Fatalf("could not get group from groups table: %s", err)
 	}
 	if !reflect.DeepEqual(got, s) {
 		t.Fatalf("got: %v, want: %v", got, s)
 	}
-	err = UpdateGroup(db, s.ID(), s)
+	err = UpdateGroup(db, s.Show, s.Category, s.Group, s)
 	if err != nil {
 		t.Fatalf("could not update group: %s", err)
 	}
-	err = DeleteGroup(db, s.ID())
+	err = DeleteGroup(db, s.Show, s.Category, s.Group)
 	if err != nil {
 		t.Fatalf("could not delete group from groups table: %s", err)
 	}

--- a/review.go
+++ b/review.go
@@ -96,7 +96,7 @@ func AddReview(db *sql.DB, r *Review) error {
 		return err
 	}
 	// 부모가 있는지 검사
-	_, err = GetVersion(db, r.Show+"/"+r.Category+"/"+r.Group+"/"+r.Unit+"/"+r.Task+"/"+r.Version)
+	_, err = GetVersion(db, r.Show, r.Category, r.Group, r.Unit, r.Task, r.Version)
 	if err != nil {
 		return err
 	}
@@ -107,12 +107,8 @@ func AddReview(db *sql.DB, r *Review) error {
 }
 
 // VersionReviews는 해당 버전의 리뷰들을 반환한다.
-func VersionReviews(db *sql.DB, id string) ([]*Review, error) {
-	show, ctg, grp, unit, task, ver, err := SplitVersionID(id)
-	if err != nil {
-		return nil, err
-	}
-	_, err = GetVersion(db, id)
+func VersionReviews(db *sql.DB, show, ctg, grp, unit, task, ver string) ([]*Review, error) {
+	_, err := GetVersion(db, show, ctg, grp, unit, task, ver)
 	if err != nil {
 		return nil, err
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -44,7 +44,7 @@ func TestTask(t *testing.T) {
 		t.Fatalf("could not add group to groups table: %s", err)
 	}
 	defer func() {
-		err = DeleteGroup(db, testGroup.ID())
+		err = DeleteGroup(db, testGroup.Show, testGroup.Category, testGroup.Group)
 		if err != nil {
 			t.Fatalf("could not delete group: %s", err)
 		}
@@ -54,27 +54,27 @@ func TestTask(t *testing.T) {
 		t.Fatalf("could not add unit: %s", err)
 	}
 	defer func() {
-		err = DeleteUnit(db, testUnitA.ID())
+		err = DeleteUnit(db, testUnitA.Show, testUnitA.Category, testUnitA.Group, testUnitA.Unit)
 		if err != nil {
 			t.Fatalf("could not delete shot: %s", err)
 		}
 	}()
 	// testUnitA가 생성되면서 testTaskA도 함께 생성된다.
 	defer func() {
-		err = DeleteTask(db, testTaskA.ID())
+		err = DeleteTask(db, testTaskA.Show, testTaskA.Category, testTaskA.Group, testTaskA.Unit, testTaskA.Task)
 		if err != nil {
 			t.Fatalf("could not delete task: %s", err)
 		}
 	}()
-	_, err = GetTask(db, testTaskA.ID())
+	_, err = GetTask(db, testTaskA.Show, testTaskA.Category, testTaskA.Group, testTaskA.Unit, testTaskA.Task)
 	if err != nil {
 		t.Fatalf("could not get task: %s", testTaskA.ID())
 	}
-	err = UpdateTask(db, testTaskA.ID(), testTaskA)
+	err = UpdateTask(db, testTaskA.Show, testTaskA.Category, testTaskA.Group, testTaskA.Unit, testTaskA.Task, testTaskA)
 	if err != nil {
 		t.Fatalf("could not update task: %s", err)
 	}
-	tasks, err := UnitTasks(db, testUnitA.ID())
+	tasks, err := UnitTasks(db, testUnitA.Show, testUnitA.Category, testUnitA.Group, testUnitA.Unit)
 	if err != nil {
 		t.Fatalf("could not get shot tasks: %s", err)
 	}

--- a/unit_test.go
+++ b/unit_test.go
@@ -98,7 +98,7 @@ func TestUnit(t *testing.T) {
 		t.Fatalf("could not add group to groups table: %s", err)
 	}
 	defer func() {
-		err = DeleteGroup(db, testGroup.ID())
+		err = DeleteGroup(db, testGroup.Show, testGroup.Category, testGroup.Group)
 		if err != nil {
 			t.Fatalf("could not delete group: %s", err)
 		}
@@ -108,7 +108,7 @@ func TestUnit(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not add unit to units table: %s", err)
 		}
-		got, err := GetUnit(db, s.ID())
+		got, err := GetUnit(db, s.Show, s.Category, s.Group, s.Unit)
 		if err != nil {
 			t.Fatalf("could not get unit from units table: %s", err)
 		}
@@ -150,11 +150,11 @@ func TestUnit(t *testing.T) {
 	}
 
 	for _, s := range want {
-		err = UpdateUnit(db, s.ID(), s)
+		err = UpdateUnit(db, s.Show, s.Category, s.Group, s.Unit, s)
 		if err != nil {
 			t.Fatalf("could not update unit: %s", err)
 		}
-		err = DeleteUnit(db, s.ID())
+		err = DeleteUnit(db, s.Show, s.Category, s.Group, s.Unit)
 		if err != nil {
 			t.Fatalf("could not delete unit from units table: %s", err)
 		}

--- a/version_test.go
+++ b/version_test.go
@@ -57,7 +57,7 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("could not add group to groups table: %s", err)
 	}
 	defer func() {
-		err = DeleteGroup(db, testGroup.ID())
+		err = DeleteGroup(db, testGroup.Show, testGroup.Category, testGroup.Group)
 		if err != nil {
 			t.Fatalf("could not delete group: %s", err)
 		}
@@ -67,19 +67,19 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("could not add shot: %v", err)
 	}
 	defer func() {
-		err = DeleteUnit(db, testUnitA.ID())
+		err = DeleteUnit(db, testUnitA.Show, testUnitA.Category, testUnitA.Group, testUnitA.Unit)
 		if err != nil {
 			t.Fatalf("could not delete shot: %v", err)
 		}
 	}()
 	// testUnitA가 생성되면서 testTaskA도 함께 생성된다.
 	defer func() {
-		err = DeleteTask(db, testTaskA.ID())
+		err = DeleteTask(db, testTaskA.Show, testTaskA.Category, testTaskA.Group, testTaskA.Unit, testTaskA.Task)
 		if err != nil {
 			t.Fatalf("could not delete task: %v", err)
 		}
 	}()
-	err = UpdateTask(db, testTaskA.ID(), testTaskA)
+	err = UpdateTask(db, testTaskA.Show, testTaskA.Category, testTaskA.Group, testTaskA.Unit, testTaskA.Task, testTaskA)
 	if err != nil {
 		t.Fatalf("could not update task: %s", err)
 	}
@@ -88,33 +88,26 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("could not add version: %v", err)
 	}
 	defer func() {
-		err = DeleteVersion(db, testVersionA.ID())
+		err = DeleteVersion(db, testVersionA.Show, testVersionA.Category, testVersionA.Group, testVersionA.Unit, testVersionA.Task, testVersionA.Version)
 		if err != nil {
 			t.Fatalf("could not delete version: %v", err)
 		}
 	}()
-	got, err := GetVersion(db, testVersionA.ID())
+	got, err := GetVersion(db, testVersionA.Show, testVersionA.Category, testVersionA.Group, testVersionA.Unit, testVersionA.Task, testVersionA.Version)
 	if err != nil {
 		t.Fatalf("could not get version: %v", err)
 	}
 	if !reflect.DeepEqual(got, testVersionA) {
 		t.Fatalf("added version is not expected: got %v, want %v", got, testVersionA)
 	}
-	shotVersions, err := UnitVersions(db, testUnitA.ID())
-	if err != nil {
-		t.Fatalf("could not get versions of shot: %v", err)
-	}
-	if len(shotVersions) != 1 {
-		t.Fatalf("shot should have 1 version at this time.")
-	}
-	taskVersions, err := TaskVersions(db, testTaskA.ID())
+	taskVersions, err := TaskVersions(db, testTaskA.Show, testTaskA.Category, testTaskA.Group, testTaskA.Unit, testTaskA.Task)
 	if err != nil {
 		t.Fatalf("could not get versions of task: %v", err)
 	}
 	if len(taskVersions) != 1 {
 		t.Fatalf("task should have 1 version at this time.")
 	}
-	err = UpdateVersion(db, testVersionA.ID(), testVersionA)
+	err = UpdateVersion(db, testVersionA.Show, testVersionA.Category, testVersionA.Group, testVersionA.Unit, testVersionA.Task, testVersionA.Version, testVersionA)
 	if err != nil {
 		t.Fatalf("could not update version: %v", err)
 	}


### PR DESCRIPTION
아이디를 넘기는게 인수의 갯수가 줄어들어 더 단순해 보였지만
대규모의 리팩토링을 하면서 컴파일시 에러가 체크되는것이 더
낫다는 생각이 들었다.

앞으로도 id는 (없어지지 않는다면) 출력 등에만 제한적으로
사용할 예정이다.

Close: #546