### PR TITLE
업데이트할 항목에 대한 아이디를 중복으로 받지 않게 함

### DIFF
--- a/cmd/roi/group_handler.go
+++ b/cmd/roi/group_handler.go
@@ -137,7 +137,7 @@ func updateGroupPostHandler(w http.ResponseWriter, r *http.Request, env *Env) er
 		s.Attrs[k] = v
 	}
 
-	err = roi.UpdateGroup(DB, show, ctg, grp, s)
+	err = roi.UpdateGroup(DB, s)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/show_handler.go
+++ b/cmd/roi/show_handler.go
@@ -155,7 +155,7 @@ func updateShowPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 		s.Attrs[k] = v
 	}
 
-	err = roi.UpdateShow(DB, id, s)
+	err = roi.UpdateShow(DB, s)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/task_handler.go
+++ b/cmd/roi/task_handler.go
@@ -83,7 +83,7 @@ func updateTaskPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 	t.ReviewVersion = r.FormValue("review_version")
 	t.WorkingVersion = r.FormValue("working_version")
 
-	err = roi.UpdateTask(DB, show, ctg, grp, unit, task, t)
+	err = roi.UpdateTask(DB, t)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func updateMultiTasksPostHandler(w http.ResponseWriter, r *http.Request, env *En
 		if assignee != "" {
 			s.Assignee = assignee
 		}
-		roi.UpdateTask(DB, show, ctg, grp, unit, task, s)
+		roi.UpdateTask(DB, s)
 	}
 	q := ""
 	for i, id := range ids {
@@ -284,7 +284,7 @@ func reviewTaskPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 		default:
 			return roi.BadRequest(fmt.Sprintf("invalid review status: %s", status))
 		}
-		err = roi.UpdateTask(DB, show, ctg, grp, unit, task, t)
+		err = roi.UpdateTask(DB, t)
 		if err != nil {
 			return err
 		}

--- a/cmd/roi/unit_handler.go
+++ b/cmd/roi/unit_handler.go
@@ -188,7 +188,7 @@ func updateUnitPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 		s.Attrs[k] = v
 	}
 
-	err = roi.UpdateUnit(DB, show, ctg, grp, unit, s)
+	err = roi.UpdateUnit(DB, s)
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func updateMultiUnitsPostHandler(w http.ResponseWriter, r *http.Request, env *En
 				s.Tasks = removeIfExist(s.Tasks, task)
 			}
 		}
-		err = roi.UpdateUnit(DB, show, ctg, grp, unit, s)
+		err = roi.UpdateUnit(DB, s)
 		if err != nil {
 			return err
 		}

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -131,7 +131,7 @@ func updateVersionPostHandler(w http.ResponseWriter, r *http.Request, env *Env) 
 	v.StartDate = timeForms["start_date"]
 	v.EndDate = timeForms["end_date"]
 
-	err = roi.UpdateVersion(DB, show, ctg, grp, unit, task, ver, v)
+	err = roi.UpdateVersion(DB, v)
 	if err != nil {
 		return err
 	}

--- a/group.go
+++ b/group.go
@@ -163,13 +163,12 @@ func Groups(db *sql.DB, show, ctg string) ([]*Group, error) {
 }
 
 // UpdateGroup은 db에서 해당 샷을 수정한다.
-// 이 함수를 호출하기 전 해당 샷이 존재하는지 사용자가 검사해야 한다.
-func UpdateGroup(db *sql.DB, show, ctg, grp string, s *Group) error {
-	err := verifyGroupPrimaryKeys(show, ctg, grp)
+func UpdateGroup(db *sql.DB, s *Group) error {
+	err := verifyGroup(db, s)
 	if err != nil {
 		return err
 	}
-	err = verifyGroup(db, s)
+	_, err = GetGroup(db, s.Show, s.Category, s.Group)
 	if err != nil {
 		return err
 	}

--- a/group_test.go
+++ b/group_test.go
@@ -53,7 +53,7 @@ func TestGroup(t *testing.T) {
 	if !reflect.DeepEqual(got, s) {
 		t.Fatalf("got: %v, want: %v", got, s)
 	}
-	err = UpdateGroup(db, s.Show, s.Category, s.Group, s)
+	err = UpdateGroup(db, s)
 	if err != nil {
 		t.Fatalf("could not update group: %s", err)
 	}

--- a/show.go
+++ b/show.go
@@ -98,13 +98,16 @@ func AddShow(db *sql.DB, s *Show) error {
 }
 
 // UpdateShow는 db의 쇼 정보를 수정한다.
-// 이 함수를 호출하기 전 해당 쇼가 존재하는지 사용자가 검사해야 한다.
-func UpdateShow(db *sql.DB, show string, s *Show) error {
+func UpdateShow(db *sql.DB, s *Show) error {
 	err := verifyShow(db, s)
 	if err != nil {
 		return err
 	}
-	stmt := fmt.Sprintf("UPDATE shows SET (%s) = (%s) WHERE show='%s'", showDBKey, showDBIdx, show)
+	_, err = GetShow(db, s.Show)
+	if err != nil {
+		return err
+	}
+	stmt := fmt.Sprintf("UPDATE shows SET (%s) = (%s) WHERE show='%s'", showDBKey, showDBIdx, s.Show)
 	if _, err := db.Exec(stmt, dbVals(s)...); err != nil {
 		return err
 	}

--- a/show_test.go
+++ b/show_test.go
@@ -68,7 +68,7 @@ func TestShow(t *testing.T) {
 	if !reflect.DeepEqual(gotAll, wantAll) {
 		t.Fatalf("got: %v, want: %v", gotAll, wantAll)
 	}
-	err = UpdateShow(db, testShow.ID(), testShow)
+	err = UpdateShow(db, testShow)
 	if err != nil {
 		t.Fatalf("could not update project: %s", err)
 	}

--- a/task.go
+++ b/task.go
@@ -209,18 +209,14 @@ func addTaskStmts(db *sql.DB, t *Task) ([]dbStatement, error) {
 }
 
 // UpdateTask는 db의 특정 태스크를 업데이트 한다.
-// 이 함수를 호출하기 전 해당 태스크가 존재하는지 사용자가 검사해야 한다.
-func UpdateTask(db *sql.DB, show, ctg, grp, unit, task string, t *Task) error {
+func UpdateTask(db *sql.DB, t *Task) error {
 	err := verifyTask(db, t)
 	if err != nil {
 		return err
 	}
-	oldt, err := GetTask(db, show, ctg, grp, unit, task)
+	_, err = GetTask(db, t.Show, t.Category, t.Group, t.Unit, t.Task)
 	if err != nil {
 		return err
-	}
-	if oldt.Category != t.Category {
-		return fmt.Errorf("not allowed to change category of task")
 	}
 	stmts := []dbStatement{
 		dbStmt(fmt.Sprintf("UPDATE tasks SET (%s) = (%s) WHERE show='%s' AND category='%s' AND grp='%s' AND unit='%s' AND task='%s'", taskDBKey, taskDBIdx, t.Show, t.Category, t.Group, t.Unit, t.Task), dbVals(t)...),

--- a/task_test.go
+++ b/task_test.go
@@ -70,7 +70,7 @@ func TestTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get task: %s", testTaskA.ID())
 	}
-	err = UpdateTask(db, testTaskA.Show, testTaskA.Category, testTaskA.Group, testTaskA.Unit, testTaskA.Task, testTaskA)
+	err = UpdateTask(db, testTaskA)
 	if err != nil {
 		t.Fatalf("could not update task: %s", err)
 	}

--- a/unit_test.go
+++ b/unit_test.go
@@ -150,7 +150,7 @@ func TestUnit(t *testing.T) {
 	}
 
 	for _, s := range want {
-		err = UpdateUnit(db, s.Show, s.Category, s.Group, s.Unit, s)
+		err = UpdateUnit(db, s)
 		if err != nil {
 			t.Fatalf("could not update unit: %s", err)
 		}

--- a/version.go
+++ b/version.go
@@ -162,15 +162,17 @@ func AddVersion(db *sql.DB, v *Version) error {
 }
 
 // UpdateVersion은 db의 특정 태스크를 업데이트 한다.
-// 이 함수를 호출하기 전 해당 태스크가 존재하는지 사용자가 검사해야 한다.
-func UpdateVersion(db *sql.DB, show, ctg, grp, unit, task, ver string, v *Version) error {
-	verifyVersionPrimaryKeys(show, ctg, grp, unit, task, ver)
+func UpdateVersion(db *sql.DB, v *Version) error {
 	err := verifyVersion(db, v)
 	if err != nil {
 		return err
 	}
+	_, err = GetVersion(db, v.Show, v.Category, v.Group, v.Unit, v.Task, v.Version)
+	if err != nil {
+		return err
+	}
 	stmts := []dbStatement{
-		dbStmt(fmt.Sprintf("UPDATE versions SET (%s) = (%s) WHERE show='%s' AND category='%s' AND grp='%s' AND unit='%s' AND task='%s' AND version='%s'", versionDBKey, versionDBIdx, show, ctg, grp, unit, task, ver), dbVals(v)...),
+		dbStmt(fmt.Sprintf("UPDATE versions SET (%s) = (%s) WHERE show='%s' AND category='%s' AND grp='%s' AND unit='%s' AND task='%s' AND version='%s'", versionDBKey, versionDBIdx, v.Show, v.Category, v.Group, v.Unit, v.Task, v.Version), dbVals(v)...),
 	}
 	return dbExec(db, stmts)
 }

--- a/version_test.go
+++ b/version_test.go
@@ -79,7 +79,7 @@ func TestVersion(t *testing.T) {
 			t.Fatalf("could not delete task: %v", err)
 		}
 	}()
-	err = UpdateTask(db, testTaskA.Show, testTaskA.Category, testTaskA.Group, testTaskA.Unit, testTaskA.Task, testTaskA)
+	err = UpdateTask(db, testTaskA)
 	if err != nil {
 		t.Fatalf("could not update task: %s", err)
 	}
@@ -107,7 +107,7 @@ func TestVersion(t *testing.T) {
 	if len(taskVersions) != 1 {
 		t.Fatalf("task should have 1 version at this time.")
 	}
-	err = UpdateVersion(db, testVersionA.Show, testVersionA.Category, testVersionA.Group, testVersionA.Unit, testVersionA.Task, testVersionA.Version, testVersionA)
+	err = UpdateVersion(db, testVersionA)
 	if err != nil {
 		t.Fatalf("could not update version: %v", err)
 	}


### PR DESCRIPTION
Update{...}함수가 지금까지 업데이트 할 항목에 대한 아이디를
중복으로 받고 있었는데, 이름을 변경하는게 아니라면 필요가 없고
이름을 변경한다면 하위 항목까지 모두 수정해야 한다.

이름을 변경하는 함수는 추후 작성할 예정.