### PR TITLE
유닛 생성시에 태스크가 지정되지 않았으면 기본 태스크를 생성

### DIFF
--- a/cmd/roi/unit_handler.go
+++ b/cmd/roi/unit_handler.go
@@ -67,16 +67,11 @@ func addUnitPostHandler(w http.ResponseWriter, r *http.Request, env *Env) error 
 	id := r.FormValue("id")
 	grp := r.FormValue("group")
 	unit := r.FormValue("unit")
-	g, err := roi.GetGroup(DB, id, grp)
-	if err != nil {
-		return err
-	}
 	s := &roi.Unit{
 		Show:   id,
 		Group:  grp,
 		Unit:   unit,
 		Status: roi.StatusInProgress,
-		Tasks:  g.DefaultTasks,
 	}
 	err = roi.AddUnit(DB, s)
 	if err != nil {

--- a/unit.go
+++ b/unit.go
@@ -234,6 +234,13 @@ func AddUnit(db *sql.DB, s *Unit) error {
 	if err != nil {
 		return err
 	}
+	if len(s.Tasks) == 0 {
+		g, err := GetGroup(db, s.Show, s.Group)
+		if err != nil {
+			return err
+		}
+		s.Tasks = g.DefaultTasks
+	}
 	// 부모가 있는지 검사
 	_, err = GetGroup(db, s.Show, s.Group)
 	if err != nil {


### PR DESCRIPTION
기존에는 유닛 핸들러에서 이 처리가 이루어졌는데, 엑셀 파일을
통해 생성한 유닛에는 기본 태스크가 생기지 않는 문제가 있었음.