### PR TITLE
roi.Error 인터페이스 삭제

### DIFF
--- a/cmd/roi/handler.go
+++ b/cmd/roi/handler.go
@@ -6,7 +6,6 @@ import (
 	"image"
 	"image/png"
 	"io"
-	"log"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -51,15 +50,18 @@ func handle(serve HandlerFunc) http.HandlerFunc {
 
 // handleError는 handle에서 요청을 처리하던 도중 에러가 났을 때 에러 메시지를 답신한다.
 func handleError(w http.ResponseWriter, err error) {
-	var e roi.Error
-	if errors.As(err, &e) {
-		if e.Log() != "" {
-			log.Print(e.Log())
-		}
-		http.Error(w, err.Error(), e.Code())
+	if errors.As(err, &roi.BadRequestError{}) {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	log.Print(err)
+	if errors.As(err, &roi.NotFoundError{}) {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	if errors.As(err, &roi.AuthError{}) {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
 	http.Error(w, "internal error", http.StatusInternalServerError)
 }
 

--- a/error.go
+++ b/error.go
@@ -2,18 +2,7 @@ package roi
 
 import (
 	"fmt"
-	"net/http"
 )
-
-// Error는 error 인터페이스를 만족하는 roi의 에러 타입이다.
-// Error는 에러와 함께 HTTP Code 정보를 가지고 있어 서버가 이를
-// 반환할수 있도록 하였다.
-// 서버는 Error가 아닌 기본 에러는 InternalServerError로 생각해야한다.
-type Error interface {
-	Error() string
-	Code() int
-	Log() string
-}
 
 // NotFoundError는 로이에서 특정 항목을 검색했지만 해당 항목이 없음을 의미하는 에러이다.
 type NotFoundError struct {
@@ -31,14 +20,6 @@ func (e NotFoundError) Error() string {
 
 func (e NotFoundError) Unwrap() error {
 	return e.err
-}
-
-func (e NotFoundError) Code() int {
-	return http.StatusNotFound
-}
-
-func (e NotFoundError) Log() string {
-	return ""
 }
 
 // BadRequestError는 로이의 함수를 호출했지만 그와 관련된 정보가 잘못되었음을 의미하는 에러이다.
@@ -59,14 +40,6 @@ func (e BadRequestError) Unwrap() error {
 	return e.err
 }
 
-func (e BadRequestError) Code() int {
-	return http.StatusBadRequest
-}
-
-func (e BadRequestError) Log() string {
-	return ""
-}
-
 // AuthError는 특정 사용자가 허락되지 않은 행동을 요청했음을 의미하는 에러이다.
 type AuthError struct {
 	err error
@@ -83,12 +56,4 @@ func (e AuthError) Error() string {
 
 func (e AuthError) Unwrap() error {
 	return e.err
-}
-
-func (e AuthError) Code() int {
-	return http.StatusUnauthorized
-}
-
-func (e AuthError) Log() string {
-	return e.err.Error()
 }


### PR DESCRIPTION
roi.Error는 로이의 에러 종류가 많았다면 효과적인 인터페이스였을수
있었겠지만 로이의 에러는 3가지이고 그나마 아직 AuthError는 사용되고
있지 않다.

서버가 이를 통해 에러를 처리할때 그 코드를 바로 이해하기 어려웠다.

또한 roi 패키지에서 http 상태를 반환하는 것이 이상해 보인다.