### PR TITLE
tmpl: site 페이지 재 디자인

### DIFF
--- a/cmd/roi/tmpl/common-style.bml
+++ b/cmd/roi/tmpl/common-style.bml
@@ -1,0 +1,40 @@
+{{define "common-style"}}
+<style> [``
+#main-bg {
+	display:flex;
+	justify-content:center;
+	padding: 3rem;
+	flex-wrap: wrap;
+	color: #aaa;
+}
+#main-left {
+	flex: 1;
+	margin:1rem;
+}
+#main-right {
+	flex: 1;
+	margin:1rem;
+}
+#main-page {
+	margin:1rem;
+}
+
+.chapter {
+	margin-bottom: 2.5rem;
+}
+.title {
+	font-size:2rem;
+	color:#ccc;
+	margin-bottom:1rem;
+}
+.subtitle {
+	font-size:1.3rem;
+	color:#ccc;
+	margin-bottom:1rem;
+}
+
+.inline {
+	display: inline-block;
+}
+``]
+{{end}}

--- a/cmd/roi/tmpl/nav.bml
+++ b/cmd/roi/tmpl/nav.bml
@@ -6,6 +6,7 @@
 	background-color: rgb(27, 28, 29);
 	display: flex;
 	height: 3rem;
+	z-index: 1001;
 }
 #main-menu .nav-item {
 	color: #f6f6f6;

--- a/cmd/roi/tmpl/site.bml
+++ b/cmd/roi/tmpl/site.bml
@@ -1,12 +1,16 @@
 {{define "site"}}
 {{template "head"}}
+{{template "common-style"}}
 {{template "nav" $}}
-<div class="ui raised very padded text container grey inverted segment"> [
-	<h2 class="ui dividing header"> [사이트 설정]
+<div id="main-bg"> [
+<div id="main-left"> [
+	<h2 class="title"> [사이트 설정]
+]
+<div id="main-page"> [
 	<form method="post" class="ui form"> [
-		<div class="field"> [
-			<div style="display:flex;color:black"> [
-				<label> [VFX 수퍼바이저]
+		<div class="chapter"> [
+			<div style="display:flex"> [
+				<div class="subtitle"> [VFX 수퍼바이저]
 				<div class="multi-input-add-button" onclick='appendTemplate("vfx_supervisors_g", "vfx_supervisors_t")'> [+]
 			]
 			<template id="vfx_supervisors_t"> [
@@ -18,10 +22,10 @@
 				{{end}}
 			]
 		]
-		<div class="field"> [
-			<div style="display:flex;color:black"> [
-				<label> [VFX 프로듀서]
-				<div class="multi-input-add-button" onclick='appendTemplate("vfx_producers_g", "vfx_producers_t")'> [+]
+		<div class="chapter"> [
+			<div style="display:flex"> [
+				<div class="inline subtitle"> [VFX 프로듀서]
+				<div class="inline multi-input-add-button" onclick='appendTemplate("vfx_producers_g", "vfx_producers_t")'> [+]
 			]
 			<template id="vfx_producers_t"> [
 				<div class="autocomplete"> [<input class="suggest-user" type="text" name="vfx_producers" onkeydown="suggest(this)" value="" />]
@@ -32,9 +36,9 @@
 				{{end}}
 			]
 		]
-		<div class="field"> [
-			<div style="display:flex;color:black"> [
-				<label> [CG 수퍼바이저]
+		<div class="chapter"> [
+			<div style="display:flex"> [
+				<div class="subtitle"> [CG 수퍼바이저]
 				<div class="multi-input-add-button" onclick='appendTemplate("cg_supervisors_g", "cg_supervisors_t")'> [+]
 			]
 			<template id="cg_supervisors_t"> [
@@ -46,9 +50,9 @@
 				{{end}}
 			]
 		]
-		<div class="field"> [
-			<div style="display:flex;color:black"> [
-				<label> [프로젝트 매니저]
+		<div class="chapter"> [
+			<div style="display:flex"> [
+				<div class="subtitle"> [프로젝트 매니저]
 				<div class="multi-input-add-button" onclick='appendTemplate("project_managers_g", "project_managers_t")'> [+]
 			]
 			<template id="project_managers_t"> [
@@ -60,9 +64,9 @@
 				{{end}}
 			]
 		]
-		<div class="field"> [
-			<div style="display:flex;color:black"> [
-				<label> [전체 태스크]
+		<div class="chapter"> [
+			<div style="display:flex"> [
+				<div class="subtitle"> [전체 태스크]
 				<div class="multi-input-add-button" onclick='appendTemplate("shot_tasks_g", "shot_tasks_t")'> [+]
 			]
 			<template id="shot_tasks_t"> [
@@ -74,9 +78,9 @@
 				{{end}}
 			]
 		]
-		<div class="field"> [
-			<div style="display:flex;color:black"> [
-				<label> [기본 샷 태스크]
+		<div class="chapter"> [
+			<div style="display:flex"> [
+				<div class="subtitle"> [기본 샷 태스크]
 				<div class="multi-input-add-button" onclick='appendTemplate("default_shot_tasks_g", "default_shot_tasks_t")'> [+]
 			]
 			<template id="default_shot_tasks_t"> [
@@ -88,9 +92,9 @@
 				{{end}}
 			]
 		]
-		<div class="field"> [
-			<div style="display:flex;color:black"> [
-				<label> [기본 애셋 태스크]
+		<div class="chapter"> [
+			<div style="display:flex"> [
+				<div class="subtitle"> [기본 애셋 태스크]
 				<div class="multi-input-add-button" onclick='appendTemplate("default_asset_tasks_g", "default_asset_tasks_t")'> [+]
 			]
 			<template id="default_asset_tasks_t"> [
@@ -102,9 +106,9 @@
 				{{end}}
 			]
 		]
-		<div class="field"> [
-			<div style="display:flex;color:black"> [
-				<label>[리드]
+		<div class="chapter"> [
+			<div style="display:flex"> [
+				<div class="subtitle">[리드]
 				<div class="multi-input-add-button" onclick='appendTemplate("leads_g", "leads_t")'>[+]
 			]
 			<template id="leads_t"> [
@@ -118,6 +122,8 @@
 		]
 		<button class="ui button green" type="submit" value="Submit"> [수정]
 	]
+]
+<div id="main-right"> []
 ]
 <script> [``
 let userName = {


### PR DESCRIPTION
기본적으로는 단순한 디자인 변경이지만 앞으로의 변화를 예고한다.
일단 메인 페이지를 좌-중간-우로 나누어 좌에는 페이지 제목,
중간에는 컨텐츠를 넣도록 하였다. (우는 아직 비워둔다.)

내용 바깥을 감싸고 있던 검은 박스형 백그라운드는  없애고 있다.

또 common-style.bml이 추가되어서 자주 쓰는 스타일을 추가했다.
템플릿에 중복으로 사용된 css의 경우 거기서는 지우고 이 파일에
추가된다.
비슷한 역할로 static/roi.css가 있는데 이 파일은 앞으로 지우고
common-style.bml을 사용하려 한다. 템플릿 디렉토리에 있어 파일을
번갈아 봐야할 때 더 편하다고 생각하기 때문이다.